### PR TITLE
📦️ Fulfill `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@openreachtech/todo-fulfill-here",
+  "name": "@openreachtech/hora-skills-ort-support",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@openreachtech/todo-fulfill-here",
+      "name": "@openreachtech/hora-skills-ort-support",
       "version": "0.0.0",
       "license": "UNLICENSED",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@openreachtech/todo-fulfill-here",
+  "name": "@openreachtech/hora-skills-ort-support",
   "version": "0.0.0",
-  "description": "TODO: fulfill here",
+  "description": "Distributes the ORT support skills used to develop with Hora Kit.",
   "type": "module",
   "main": "index.js",
   "files": [
@@ -10,6 +10,12 @@
     "!types/env/**"
   ],
   "types": "./types/index.d.ts",
+  "keywords": [
+    "hora",
+    "hora-kit",
+    "ai",
+    "support"
+  ],
   "scripts": {
     "l": "npm run lint",
     "lint": "eslint .",
@@ -17,14 +23,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openreachtech/todo-fulfill-here.git"
+    "url": "git+https://github.com/openreachtech/hora-skills-ort-support.git"
   },
   "author": "Open Reach Tech Inc.",
   "license": "UNLICENSED",
   "bugs": {
-    "url": "https://github.com/openreachtech/todo-fulfill-here/issues"
+    "url": "https://github.com/openreachtech/hora-skills-ort-support/issues"
   },
-  "homepage": "https://github.com/openreachtech/todo-fulfill-here#readme",
+  "homepage": "https://github.com/openreachtech/hora-skills-ort-support#readme",
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

* Close #1

# How

* Fills in what the template leaves as `todo-fulfill-here`: the package name, a description in the shape its three sibling packages use, the repository, bugs and homepage URLs, and the `hora` / `hora-kit` / `ai` / `support` keywords
* `version` stays `0.0.0`, and the rest of the manifest is left to the pull requests that add the build, the equip CLI and the license
