### PR TITLE
Env > Main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@openreachtech/todo-fulfill-here",
+  "name": "@openreachtech/hora-skills-ort-support",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@openreachtech/todo-fulfill-here",
+      "name": "@openreachtech/hora-skills-ort-support",
       "version": "0.0.0",
       "license": "UNLICENSED",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@openreachtech/todo-fulfill-here",
+  "name": "@openreachtech/hora-skills-ort-support",
   "version": "0.0.0",
-  "description": "TODO: fulfill here",
+  "description": "Distributes the ORT support skills used to develop with Hora Kit.",
   "type": "module",
   "main": "index.js",
   "files": [
@@ -10,6 +10,12 @@
     "!types/env/**"
   ],
   "types": "./types/index.d.ts",
+  "keywords": [
+    "hora",
+    "hora-kit",
+    "ai",
+    "support"
+  ],
   "scripts": {
     "l": "npm run lint",
     "lint": "eslint .",
@@ -17,14 +23,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openreachtech/todo-fulfill-here.git"
+    "url": "git+https://github.com/openreachtech/hora-skills-ort-support.git"
   },
   "author": "Open Reach Tech Inc.",
   "license": "UNLICENSED",
   "bugs": {
-    "url": "https://github.com/openreachtech/todo-fulfill-here/issues"
+    "url": "https://github.com/openreachtech/hora-skills-ort-support/issues"
   },
-  "homepage": "https://github.com/openreachtech/todo-fulfill-here#readme",
+  "homepage": "https://github.com/openreachtech/hora-skills-ort-support#readme",
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

* Merges the environment setup into `main`, so the release line can be cut from it

# How

* Carries the two commits of #1: the fulfilled `package.json` and its lock
* The title names no version, on purpose. `release.yml` reads a backtick-quoted version from the title, and at the three sibling repositories a title of the shape ``Env > Main `0.0.0` `` made it create the `0.0.0` tag and GitHub Release here, on the env merge instead of the release merge. Both had to be deleted by hand

<!--
* All commits have already been reviewed, merge only
-->
