### PR TITLE
🤖 Add the support skills migrated from `hora-skills`

### DIFF
--- a/kit/skills/hos-explain/SKILL.md
+++ b/kit/skills/hos-explain/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: hos-explain
+description: "Rewrite an AI-generated explanation, report or proposal into plain language with diagrams, so that a reader with no technical background — a junior-high-school student is the bar — can understand it in one read. Use when an AI answer is too long or too hard, when sharing a conclusion with non-engineers, or when asked to explain simply or with diagrams. It only rewrites an existing message and adds no new analysis; end-user product manuals belong to the user-manual skill."
+---
+
+# Explain
+
+Turn a long, jargon-heavy AI message into text that a reader with no technical background can
+understand in one read. The target reader is a **junior-high-school student**. If a sentence needs
+a footnote for that reader, rewrite the sentence.
+
+The input is a message that already exists: an explanation, a review result, a proposal, an error
+analysis. This skill **only rewrites**. Do not add new analysis, conclusions, or facts. If the
+original is wrong, the plain version stays wrong in the same way. Fixing content is a different
+task.
+
+## Core rule: rebuild, do not shorten
+
+A shorter hard text is still hard. Throw away the original structure and rebuild:
+
+1. **Extract first, write second.** Before writing, pull out only the sentences that change what
+   the reader decides or does. Drop everything else: hedges, methodology, options that were
+   rejected. The test for each fact: "Does the reader act differently without this?" If no, drop
+   it.
+2. **Use the fixed format.** Every output has the same four parts in the same order
+   ([`references/output-format.md`](./references/output-format.md)). A reader who has seen one
+   output can read all of them.
+3. **Always include a diagram.** Structure, order, and relationships are hard to read in prose.
+   Put them in a diagram instead. Use one or two diagrams, chosen by the shape of the content
+   ([`references/diagram-catalog.md`](./references/diagram-catalog.md)).
+
+## The four parts
+
+| # | Part | Rule |
+|---|---|---|
+| 1 | **Conclusion** | One sentence, about 40 characters in Japanese (about 15 words in English). What this is, or what the reader should do. Nothing comes before it. |
+| 2 | **Diagram** | 1–2 diagrams. Mermaid is the first choice. At most 5 elements per diagram. One message per diagram. |
+| 3 | **Points** | At most 3 bullets. One sentence each. |
+| 4 | **Words** | A small glossary. Only the technical terms the output could not avoid, one line each, each with an everyday analogy. Skip this section when no term is left. |
+
+The full format, with a good example and a bad example, is in
+[`references/output-format.md`](./references/output-format.md).
+
+## Language rules
+
+- **Write in the reader's language.** The reader is whoever the plain version will be shown to.
+  Normally that is the person asking, so answer in the language they used.
+- **Replace jargon with an everyday word**, and put the original term in parentheses the first
+  time: 「設計図(スキーマ)」, "a to-do list the server works through (a job queue)". After the
+  first time, use the everyday word alone.
+- **Use active voice and verbs.** "The server checks the password", not "password validation is
+  performed".
+- **One idea per sentence.** A sentence with two clauses is two sentences.
+- Full word-level rules, with a substitution table for common terms, are in
+  [`references/wording-rules.md`](./references/wording-rules.md).
+
+## Choosing the diagram
+
+Pick by the shape of the content:
+
+| The content is… | Draw |
+|---|---|
+| A procedure, a sequence of events | Flowchart (top to bottom) |
+| Things and how they relate | Block diagram |
+| A choice between options | Comparison table |
+| Sizes, amounts, proportions | Bar lengths |
+| Things happening over time | Timeline |
+
+Mermaid snippets for each shape are in
+[`references/diagram-catalog.md`](./references/diagram-catalog.md).
+
+## Out of scope
+
+- **Do not answer new questions.** If the original message does not answer the reader's question,
+  say so. Do not fill the gap with new reasoning.
+- **Do not soften bad news.** "The tests fail" stays "the tests fail". Plainer, never rosier.
+- **Do not write product manuals.** A user-facing operation manual is the user-manual skill's
+  job. This skill explains messages, not products.

--- a/kit/skills/hos-explain/references/diagram-catalog.md
+++ b/kit/skills/hos-explain/references/diagram-catalog.md
@@ -1,0 +1,69 @@
+# Diagram Catalog
+
+Pick the diagram from the shape of the content. Two limits apply to every shape: **at most 5
+elements**, and **one message per diagram**. When the content is bigger than that, drop elements
+or split into two diagrams. Never grow one diagram.
+
+## Procedure / sequence → flowchart
+
+For "first this happens, then that". Top to bottom, one arrow per step. Add a branch only when
+the branch *is* the message.
+
+```mermaid
+flowchart TD
+    A[ユーザーがボタンを押す] --> B[サーバーが注文を受け取る]
+    B --> C[在庫を確認する]
+    C --> D[確認メールを送る]
+```
+
+## Things and relationships → block diagram
+
+For "A talks to B, B stores into C". Use `flowchart LR`: boxes for things, labeled arrows for the
+relationship. If an arrow needs a long label, that text belongs in a point, not in the diagram.
+
+```mermaid
+flowchart LR
+    A[アプリ] -->|注文を送る| B[サーバー]
+    B -->|記録する| C[(データベース)]
+```
+
+## Choice between options → comparison table
+
+A table *is* the diagram for comparisons. Rows are options. Columns are the 2–3 things the
+decision turns on. Mark the recommended row in words ("←おすすめ"), not only by position.
+
+| 案 | 手間 | 危険度 |
+|---|---|---|
+| 一度に直す | 小 | 高い |
+| 二回に分けて直す ←おすすめ | 中 | 低い |
+
+## Sizes and proportions → bar lengths
+
+For "A is much bigger than B". Rough bars in a table beat exact numbers the reader cannot feel.
+Round hard; the message is the ratio.
+
+| 処理 | かかる時間 |
+|---|---|
+| 画像の読み込み | ████████ 8秒 |
+| その他すべて | █ 1秒 |
+
+## Things over time → timeline
+
+For "this happened, then a week later that". Use Mermaid `timeline`, or a flowchart with dates in
+the labels when the renderer may not support `timeline`.
+
+```mermaid
+timeline
+    4月 : 開発を始めた
+    6月 : テストで問題が見つかった
+    7月 : 直して公開した
+```
+
+## Rules for every diagram
+
+- **One message.** Ask: "What single sentence does this diagram prove?" If the answer has an
+  "and", split the diagram.
+- **Five elements.** Boxes, rows, bars, or events — 5 is the ceiling.
+- **Everyday labels.** The wording rules apply inside the diagram too. A diagram full of jargon
+  is the original message in boxes.
+- **No decoration.** No colors for their own sake, no icons. The shape carries the meaning.

--- a/kit/skills/hos-explain/references/output-format.md
+++ b/kit/skills/hos-explain/references/output-format.md
@@ -1,0 +1,92 @@
+# Output Format
+
+Every plain version has the same four parts, in this order. Nothing comes before part 1 and
+nothing comes after part 4.
+
+## Skeleton
+
+````markdown
+**つまり**:<conclusion in one sentence>
+
+<diagram (1–2, Mermaid preferred)>
+
+**ポイント**
+- <point 1>
+- <point 2>
+- <point 3>
+
+**ことば**
+- **<term>** … <one-line everyday explanation, with an analogy>
+````
+
+Match the headings to the output language (`**In short**` / `**Points**` / `**Words**` in
+English). The parts and their order never change.
+
+## Part rules
+
+### 1. Conclusion — one sentence
+
+- About 40 characters in Japanese, about 15 words in English. One sentence, one full stop.
+- It answers "so what is this?" or "so what should I do?" — whichever the original message was
+  about. If the original recommends an action, the conclusion is that action.
+- Do not open with context ("As you asked previously…"). The conclusion is line one.
+
+### 2. Diagram — required
+
+- 1 or 2 diagrams, never more. Use two only when the content has two shapes (for example, a
+  procedure *and* a comparison).
+- Mermaid is the first choice. A Markdown table is the right "diagram" for comparisons. Use ASCII
+  layout only when neither fits.
+- **At most 5 boxes, nodes, or rows per diagram.** More than 5 means extraction was skipped. Go
+  back and drop elements, or split into two diagrams with one message each.
+- Label nodes in everyday words. The same substitution rules as prose apply.
+
+### 3. Points — at most 3
+
+- One sentence per bullet, about 40 characters per sentence.
+- Points support the conclusion. Do not introduce topics the conclusion did not touch.
+- Order by importance to the reader, not by the original's order.
+- Fewer than 3 is fine. Zero is not — with nothing beyond the conclusion, the original did not
+  need this skill.
+
+### 4. Words — only what is left
+
+- List only terms actually used above. Do not teach vocabulary the output avoided.
+- One line per term: everyday explanation first, analogy after. "**キャッシュ** … 一度調べたことを
+  メモしておく仕組み。次に聞かれたとき即答できる。"
+- Skip the whole section when no technical term is left. That is the best outcome.
+
+## Worked example
+
+Original (abridged):
+
+> マイグレーション実行時に `users` テーブルへの `email` カラム追加が unique 制約違反で失敗して
+> います。既存レコードに重複した email 値が存在するためで、制約を付与する前にデータクレンジング
+> を行うか、一旦 nullable で追加してから重複解消後に制約を付与する二段階マイグレーションが必要
+> です。なお、本番環境への適用前にステージングでの検証を推奨します。
+
+Good plain version:
+
+````markdown
+**つまり**:同じメールアドレスが複数登録されているので、先に重複を片づけないと変更できません。
+
+```mermaid
+flowchart TD
+    A[重複したメールを整理する] --> B[メール欄を追加する]
+    B --> C[「重複禁止」のルールを付ける]
+```
+
+**ポイント**
+- データベースに「同じメールは登録できない」ルールを足そうとして失敗した
+- すでに同じメールの人が複数いるため、ルールと矛盾してしまう
+- 本番でやる前に、練習用の環境で一度試す
+
+**ことば**
+- **マイグレーション** … データベースの作り変え作業。引っ越しの段取り表のようなもの。
+````
+
+Bad plain version (do not do this):
+
+> マイグレーションが unique 制約違反で失敗しました。二段階マイグレーションで対応します。
+
+It is shorter, but every hard word is still there. This is shortening, not rebuilding.

--- a/kit/skills/hos-explain/references/wording-rules.md
+++ b/kit/skills/hos-explain/references/wording-rules.md
@@ -1,0 +1,63 @@
+# Wording Rules
+
+The bar for every sentence: a junior-high-school student reads it once and does not stop.
+
+## Sentence rules
+
+- **One idea per sentence.** Split at every "、〜が、", "、〜し、", "; " and " but ".
+- **About 40 characters per sentence in Japanese** (about 15 words in English). This is a limit,
+  not a target to fill.
+- **Active voice.** Name who does what: 「サーバーがパスワードを確認します」, not
+  「パスワードの検証が行われます」.
+- **Verbs over abstract nouns.** 「速くする」 not 「高速化を実現する」; "check" not "perform
+  validation".
+- **No hedging chains and no double negatives.** 「〜の可能性も考えられなくはない」 becomes
+  「〜かもしれない」, or gets dropped during extraction.
+- **Give numbers a feel.** "300ms" alone means nothing to this reader. "0.3秒 — まばたきくらい"
+  does. Round to the precision the decision needs.
+
+## Jargon substitution
+
+First appearance: everyday word + original term in parentheses. After that: everyday word alone.
+
+「設計図(スキーマ)を直してから…その設計図に合わせて…」
+
+Substitutions that work for terms common in this stack:
+
+| Term | Everyday substitution |
+|---|---|
+| データベース / DB | データを保存しておく場所(データベース) |
+| スキーマ | データベースの設計図(スキーマ) |
+| マイグレーション | データベースの作り変え作業(マイグレーション) |
+| API | プログラム同士の窓口(API) |
+| キャッシュ | 一度調べた結果のメモ(キャッシュ) |
+| ジョブキュー | あとでやる仕事の順番待ちリスト(ジョブキュー) |
+| デプロイ | 作ったものを本番に置くこと(デプロイ) |
+| リクエスト / レスポンス | 問い合わせ / その返事 |
+| バリデーション | 入力内容のチェック(バリデーション) |
+| タイムアウト | 待ち時間切れ(タイムアウト) |
+| 認証 | 本人確認(認証) |
+| セッション | ログイン中であることの記録(セッション) |
+
+The table is a starting point. Substitute any other term the same way: say what it does, in words
+the reader already knows, with the original in parentheses once.
+
+## Analogies
+
+- One analogy per term, one line. An analogy that needs its own explanation is worse than none.
+- Draw from shared everyday experience: school, shopping, mail, cooking. Do not draw from other
+  technology ("like Docker but…" explains nothing to this reader).
+- Do not let the analogy overclaim. If the real mechanism differs in a way that matters to the
+  reader's decision, drop the analogy.
+
+## What extraction drops
+
+These almost never survive into the plain version:
+
+- Methodology ("3つの観点でレビューした結果…") — the reader needs the findings, not the process.
+- Options that were considered and rejected, unless the reader is the one choosing.
+- Caveats that do not change the reader's action.
+- Apologies, praise, and filler ("ご指摘の通り…", "素晴らしい質問です").
+
+The test for every fact is always the same: **does the reader act differently without this?**
+If no, drop it.

--- a/kit/skills/hos-user-manual/SKILL.md
+++ b/kit/skills/hos-user-manual/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: hos-user-manual
+description: "Generate end-user operation manuals by driving the system for real: start the local E2E environment, log in as a test user, walk each feature in the UI, and write one HTML page per feature with screenshots plus a table-of-contents page, under a directory bound to the product version. Requires an already-built E2E environment (building it is the E2E build convention's job). Use when asked for a user manual / 利用マニュアル / operation guide; developer-facing docs belong to the documentation convention."
+---
+
+# User Manual
+
+Create the manual an **end user** reads to operate the system. This is not a README and not an
+architecture document. Each feature gets one HTML page of numbered steps with screenshots. A
+table-of-contents page links the pages together. The whole set lives in a directory named after
+the product version.
+
+## Core rule: write only what you actually did
+
+Do not write the manual from the source code. Write it from real operation: perform every step in
+the running system, through the UI, during this run. Every screenshot shows a screen that really
+appeared. If a step cannot be performed (broken feature, missing data, missing permission), do
+not write around it. Report the gap to the user as a finding.
+
+Two consequences:
+
+- **The E2E environment is a hard prerequisite.** The whole stack must run for real. Building
+  that environment is its own convention (`hor-build-e2e-test-environment`). If the repository has
+  no E2E environment, stop and point the user there first.
+- **The manual is bound to one product version** — the consuming repository's `package.json`
+  `version`. A new version gets a new directory. Old versions are history: never edit them
+  ([`references/versioning.md`](./references/versioning.md)).
+
+## Workflow
+
+1. **Check the prerequisite.** Confirm the E2E environment exists and find its commands
+   (`up` / `start` / `seed` / `clean` / `down` or the project's equivalents). If it is missing,
+   stop and point to the E2E build convention.
+2. **Start the environment and seed it.** Bring the stack up and load the seed data.
+   **Reuse the existing test seeders as far as they go.** They are the default material for the
+   manual's screenshots, and they are already maintained. When a feature needs data the seeders
+   do not provide, **stop and ask the user** before adding anything:
+   - Add the missing data at all? If yes, as a proper seeder in the E2E seed set, or as
+     throwaway records created through the UI?
+   - Clean the additions up after the run, or keep them?
+   Record the answers. Never grow the seed set without asking, and never leave manual-run data
+   behind without asking.
+3. **Log in as a test user.** Use a seeded test user and sign in through the UI. The login
+   screenshots come from this step. Use an account with the same permissions the manual's reader
+   has. An admin account shows menus the reader will never see.
+4. **List the features.** Build the feature list from the UI's own navigation, cross-checked
+   against any requirement definition. **Confirm the list with the user before writing.** The
+   list becomes the table of contents, so scope questions are settled here, not after twenty
+   pages.
+5. **Walk, capture, write — one feature at a time.** Operate the feature end to end. Capture a
+   screenshot per meaningful step
+   ([`references/capture-workflow.md`](./references/capture-workflow.md)), then write that
+   feature's page ([`references/manual-page-template.md`](./references/manual-page-template.md)).
+   One feature = one HTML file.
+6. **Write the table of contents.** `index.html` is **required** — a manual set without it is
+   incomplete. It lists every feature page, the product version, and the generation date
+   ([`references/toc-template.md`](./references/toc-template.md)).
+7. **Tear down.** Stop the environment. If step 2 added throwaway data and the user chose
+   cleanup, remove it now and say so in the final report.
+
+## Output layout
+
+```
+docs/manuals/
+├── v0.3.0/                    ← bound to the product version: 1 version = 1 directory
+│   ├── index.html             ← table of contents — required
+│   ├── assets/
+│   │   ├── manual.css         ← shared stylesheet, copied from the page template reference
+│   │   └── images/            ← screenshots, named <feature>-<step number>.png
+│   └── features/
+│       ├── login.html         ← 1 feature = 1 file
+│       └── ...
+└── v0.2.0/                    ← previous versions stay as written
+```
+
+## Rules
+
+| Rule | Meaning |
+|---|---|
+| Table of contents required | No `index.html`, no manual. It carries the feature list, target version, and generation date. |
+| One feature, one file | Pages are reached through the TOC and previous/next links. No single giant page. |
+| Self-contained HTML | Styled by the bundled `manual.css`. No external CDNs. Images use relative paths. The directory must open from the filesystem as-is. |
+| Version-bound | Output goes under `docs/manuals/v<version>/` only. A new version means a new directory. Never edit an old one. |
+| Operation-based | Only steps actually performed and screenshots actually captured. Report steps that could not be performed; do not invent them. |
+| Reader's language | Write the manual in the end user's language, whatever language this skill was invoked in. |

--- a/kit/skills/hos-user-manual/references/capture-workflow.md
+++ b/kit/skills/hos-user-manual/references/capture-workflow.md
@@ -1,0 +1,67 @@
+# Capture Workflow
+
+How each feature is walked and photographed. The rule this file serves: **only what was actually
+performed and actually captured enters the manual.**
+
+## Driving the system
+
+- Operate through the browser against the running E2E stack, the way an end user would: navigate,
+  click, type. Any browser automation the session has is fine. The tool does not matter; the
+  discipline does. Every screenshot comes from a real rendered screen of this run.
+- **Use one fixed viewport for the whole run** (1280×800 is a good default). Mixed sizes make the
+  manual look stitched together.
+- Use the seeded test user chosen in the login step, with the same permissions the manual's
+  reader has. If different roles see different UIs, walk each role's pages under that role's
+  account.
+
+## Seed data during the walk
+
+- The E2E seed set is the material on screen. **Reuse the existing test seeders as far as they
+  go.** They are maintained, realistic, and reproducible.
+- When a feature needs data the seeders do not provide (for example, a cancellation page with no
+  cancellable order seeded), **stop and ask the user**. Never improvise. Ask:
+  1. Add the missing data at all? If yes, as a proper seeder in the E2E seed set (kept and
+     maintained, helps future runs), or as throwaway records created through the UI for this run
+     only?
+  2. Clean the additions up after the run, or keep them?
+  Record the answers. The teardown step executes them, and the final report states them.
+- Data created *as part of a documented operation* (the record the reader is shown how to create)
+  is not seed data. It is the walk itself. It still falls under the same cleanup decision.
+
+## What to capture
+
+One screenshot per **meaningful step**: a screen the reader must recognize, or a state the reader
+must produce. Concretely:
+
+- The screen as the step begins, so the reader can confirm "I am in the right place".
+- Forms **after** filling them in, before submitting. A filled form teaches; an empty one does
+  not.
+- The visible result of the action: the success message, the new row, the changed status.
+- Any dialog or confirmation the reader must answer.
+
+Not every click needs a frame. Navigating three menu levels is one step with one screenshot of
+the destination, with the path written in the step text.
+
+## Screenshot hygiene
+
+- **Naming**: `<feature>-<step number>.png` under `assets/images/` — `login-1.png`,
+  `login-2.png`. The name ties the file to its page and step. Delete any screenshot no page
+  references.
+- **Check the content before saving**, every time:
+  - No real personal data. Seeded fictional users only. If a screen shows anything that did not
+    come from seed data or from this walk, stop and find out why before publishing it.
+  - No developer chrome: no devtools pane, no error overlays, no bookmark-bar noise. The frame is
+    the application as the reader sees it.
+  - The state matches the step text. A screenshot of a slightly different state (another record
+    selected, another tab active) is worse than none. Retake it.
+- Capture the full window by default. Crop to a region only when the step is about one control
+  and the full screen would make it too small to read. When cropping, keep enough surroundings
+  for the reader to find the control.
+
+## When a step cannot be performed
+
+A feature that errors, a button that does nothing, a permission that blocks the walk: **do not
+write the step from imagination, and do not silently drop the feature.** Leave the feature's page
+out (or mark the specific step as unavailable), and report the finding to the user at the end:
+what was attempted, what happened, and that the manual omits it. A gap with a reported reason is
+fine. A made-up page is a defect.

--- a/kit/skills/hos-user-manual/references/manual-page-template.md
+++ b/kit/skills/hos-user-manual/references/manual-page-template.md
@@ -1,0 +1,171 @@
+# Feature Page Template
+
+One feature = one HTML file under `features/`. Every page uses the same skeleton and the same
+shared stylesheet, so the whole manual reads as one document.
+
+## Page skeleton
+
+`features/<feature>.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ログイン | 利用マニュアル v0.3.0</title>
+  <link rel="stylesheet" href="../assets/manual.css">
+</head>
+<body>
+  <header class="page-header">
+    <a class="toc-link" href="../index.html">← 目次へ戻る</a>
+    <p class="version">v0.3.0</p>
+  </header>
+
+  <main>
+    <h1>ログイン</h1>
+    <p class="lead">登録済みのアカウントでシステムにサインインします。</p>
+
+    <section class="step">
+      <h2><span class="step-no">1</span>ログイン画面を開く</h2>
+      <p>ブラウザでシステムの URL を開くと、ログイン画面が表示されます。</p>
+      <figure>
+        <img src="../assets/images/login-1.png" alt="ログイン画面">
+        <figcaption>ログイン画面</figcaption>
+      </figure>
+    </section>
+
+    <section class="step">
+      <h2><span class="step-no">2</span>メールアドレスとパスワードを入力する</h2>
+      <p>登録したメールアドレスとパスワードを入力し、「ログイン」ボタンを押します。</p>
+      <figure>
+        <img src="../assets/images/login-2.png" alt="入力済みのログインフォーム">
+        <figcaption>入力後、「ログイン」ボタンを押す</figcaption>
+      </figure>
+      <aside class="note">パスワードを忘れた場合は「パスワードを忘れた方」から再設定できます。</aside>
+    </section>
+  </main>
+
+  <nav class="pager">
+    <a class="prev" href="./previous-feature.html">← 前:○○</a>
+    <a class="next" href="./next-feature.html">次:○○ →</a>
+  </nav>
+</body>
+</html>
+```
+
+## Page rules
+
+- **Title** is `<feature name> | 利用マニュアル v<version>` — the version is visible in the tab.
+- **Lead paragraph**: one sentence, what the user gets done with this feature. Write for the end
+  user: name things as the screen names them, not as the code does.
+- **One `section.step` per operation step**, numbered by `span.step-no`, in the order actually
+  performed. A step is one user action and its visible result.
+- **Every step has a screenshot** (`figure > img + figcaption`), referenced relatively as
+  `../assets/images/<feature>-<step>.png`. The caption says what the reader should see or do,
+  not what the file is.
+- **`aside.note`** holds a tip or warning the reader may need at that step. Use it rarely.
+- **`nav.pager`** links the previous and next feature in TOC order. The first page has no `prev`,
+  the last page has no `next`. `← 目次へ戻る` appears on every page.
+- No external CDNs. No scripts needed to read the page. The manual must open from the local
+  filesystem.
+
+## Shared stylesheet
+
+Written once per manual version, to `assets/manual.css`:
+
+```css
+:root {
+  --ink: #24292f;
+  --ink-soft: #57606a;
+  --line: #d8dde3;
+  --accent: #2b5a8c;
+  --accent-soft: #eaf1f8;
+  --paper: #ffffff;
+  --note-bg: #fff8e6;
+  --note-edge: #d4a72c;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif;
+  line-height: 1.9;
+}
+
+main { max-width: 46rem; margin: 0 auto; padding: 1rem 1.5rem 4rem; }
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.8rem 1.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.page-header .toc-link { color: var(--accent); text-decoration: none; }
+
+.page-header .version { color: var(--ink-soft); font-size: 0.85rem; margin: 0; }
+
+h1 { font-size: 1.7rem; line-height: 1.4; margin: 1.6rem 0 0.4rem; }
+
+.lead { color: var(--ink-soft); margin-top: 0; }
+
+.step { margin-top: 2.5rem; }
+
+.step h2 {
+  font-size: 1.15rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 2px solid var(--accent-soft);
+}
+
+.step-no {
+  display: inline-grid;
+  place-items: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.9rem;
+  flex: none;
+}
+
+figure { margin: 1.2rem 0; }
+
+figure img {
+  max-width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+}
+
+figcaption { color: var(--ink-soft); font-size: 0.85rem; margin-top: 0.4rem; }
+
+.note {
+  background: var(--note-bg);
+  border-left: 3px solid var(--note-edge);
+  padding: 0.7rem 1rem;
+  border-radius: 0 6px 6px 0;
+  font-size: 0.92rem;
+}
+
+.pager {
+  display: flex;
+  justify-content: space-between;
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 1rem 1.5rem 3rem;
+  border-top: 1px solid var(--line);
+}
+
+.pager a { color: var(--accent); text-decoration: none; }
+```
+
+Adjust `--accent` to the product's brand color when it has one. Keep everything else the same, so
+manuals of different versions look alike.

--- a/kit/skills/hos-user-manual/references/toc-template.md
+++ b/kit/skills/hos-user-manual/references/toc-template.md
@@ -1,0 +1,81 @@
+# Table of Contents Template
+
+`index.html` is **required**. Readers start here, and every feature page links back here. A
+manual set without it is incomplete.
+
+## Required content
+
+| Item | Where |
+|---|---|
+| Product name and「利用マニュアル」 | `h1` |
+| Target version (`v<version>`) | Header, visible without scrolling |
+| Generation date | Header |
+| Every feature page, linked, in reading order | The list — every published page must appear in it |
+| One-line summary per feature | Under each link |
+
+## Skeleton
+
+```html
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>利用マニュアル v0.3.0 | <product name></title>
+  <link rel="stylesheet" href="./assets/manual.css">
+</head>
+<body>
+  <main>
+    <h1><product name> 利用マニュアル</h1>
+    <p class="lead">対象バージョン:v0.3.0 / 作成日:2026-08-24</p>
+
+    <section class="step">
+      <h2>はじめに</h2>
+      <ol class="toc">
+        <li>
+          <a href="./features/login.html">ログイン</a>
+          <p>アカウントでシステムにサインインする</p>
+        </li>
+      </ol>
+    </section>
+
+    <section class="step">
+      <h2>基本操作</h2>
+      <ol class="toc">
+        <li>
+          <a href="./features/user-registration.html">ユーザー登録</a>
+          <p>新しい利用者を登録する</p>
+        </li>
+        <!-- one li per feature page, in reading order -->
+      </ol>
+    </section>
+  </main>
+</body>
+</html>
+```
+
+Add to `assets/manual.css` for the TOC list:
+
+```css
+.toc { padding-left: 1.4rem; }
+
+.toc li { margin: 0.8rem 0; }
+
+.toc a { color: var(--accent); font-weight: 600; text-decoration: none; }
+
+.toc p { margin: 0.1rem 0 0; color: var(--ink-soft); font-size: 0.9rem; }
+```
+
+## TOC rules
+
+- **Reading order, grouped when it helps.** Order features as a new user meets them: signing in
+  first, everyday operations before administration. Group under `h2` headings only when there
+  are enough features for groups to help scanning (roughly 8 or more). A short manual keeps one
+  flat list.
+- **The TOC is the completeness check.** After writing, check both directions: every file under
+  `features/` appears in the TOC, and every TOC link points to a file. Fix any mismatch before
+  finishing.
+- **The pager follows the TOC.** The previous/next links on feature pages use TOC order, so
+  decide the TOC order before filling in the pagers.
+- The feature list was confirmed with the user before writing began. Do not change the scope
+  here.

--- a/kit/skills/hos-user-manual/references/versioning.md
+++ b/kit/skills/hos-user-manual/references/versioning.md
@@ -1,0 +1,39 @@
+# Versioning
+
+The manual describes the system **as it behaved when it was walked**. So every manual set is
+bound to the product version it was written against, and it stays that way.
+
+## The binding
+
+- The version is the consuming repository's `package.json` `version` at the time of the run.
+- Output goes to `docs/manuals/v<version>/` — the literal `version` string with a `v` prefix:
+  `0.3.0` → `docs/manuals/v0.3.0/`.
+- The version also appears inside the manual: in the TOC header and in every page's `<title>`.
+  A printed or copied page still says what it describes.
+
+## One version, one directory
+
+```
+docs/manuals/
+├── v0.3.0/        ← current: the only directory this run may write into
+├── v0.2.0/        ← history: never edited
+└── v0.1.0/        ← history: never edited
+```
+
+- **Never edit a past version's directory.** It records how that version worked. Changing it to
+  match today's system destroys that record. Fix a mistake found in an old manual in the current
+  version's manual instead.
+- **A new product version gets a fresh directory**, walked and captured against the new version.
+  Screenshots age fastest, and carrying them forward silently is how manuals drift from the
+  product. Unchanged features may reuse the previous version's *text* as a starting draft, but
+  every screenshot in the new directory comes from a walk of the new version.
+- **Re-running for the same version overwrites in place.** Regenerating `docs/manuals/v0.3.0/`
+  while the product is still `0.3.0` replaces that directory's content. There are no
+  `v0.3.0-final2` variants.
+
+## Partial updates
+
+Updating a single feature's page within the current version (a screen changed in a patch, a page
+had an error) is allowed, with the same discipline as a full run: walk that feature for real,
+recapture its screenshots, and update the TOC's generation date. Never edit a page's steps
+without re-walking them.


### PR DESCRIPTION
# Why

* Close #4

# How

* Migrates the two support skills of `hora-skills`, 9 files, renaming the prefix `hs-` to `hos-` so it reads like the three sibling packages: `hoc-` core, `hor-` renchan, `hof-` furo
* The skills sit **directly under `kit/skills/`**, with no domain directory. The package is the domain, so a folder repeating it carries nothing, and the flatten build added next needs no domain map because of it
* `hs-user-manual` pointed at `hb-build-e2e-test-environment` for the environment it needs. That skill is now `hor-build-e2e-test-environment` in `hora-skills-ort-renchan`, so the reference is renamed too — left as it was, it would name a skill that no longer exists
