### PR TITLE
🧵 Ignore `kit/` in `eslint.config.js`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,10 @@ export default [
 
   {
     ignores: [
+      // dist/ is generated build output (see the flatten skill), not source.
       './dist/**',
+
+      './kit/**',
     ],
   },
 


### PR DESCRIPTION
# Why

* Close #6

# How

* `kit/` is the distributed material, not the source of this package: it is written for the agent that reads it, and the flatten build copies it as it stands. Linting it reports on files nobody edits by hand here
* Matches the three sibling packages, where the same ignore was needed once the kit carried scripts of its own
* The comment above `./dist/**` is the one the siblings carry, so the two ignores read as one decision
