### PR TITLE
🏗️ Add the build and the skill-name audit

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: audit
+description: "Repository-specific check: reports every skill under kit/skills/ whose folder name, SKILL.md or placement would stop the build — a wrong name, a missing or mismatched name: field, a nested skill, a stray file. Reads only, writes nothing. Use before opening a pull request that touches kit/skills/, or when the build aborts and the whole list of problems is wanted at once."
+---
+
+# Audit
+
+The build refuses to write `dist/skills/` while the source tree is invalid. This skill reports the same problems without touching anything, so the tree can be fixed before a build, and so CI can fail a pull request that breaks the layout.
+
+```
+npm run skill-names
+```
+
+or
+
+```
+node .claude/skills/audit/scripts/audit.js
+```
+
+It prints how many skills it checked, then one group per kind of problem, and exits non-zero when there is at least one. A clean tree prints `No problem found.`
+
+## What it reports
+
+| Group | Meaning |
+|---|---|
+| `Not a skill directory` | Something that is not a directory sits directly under `kit/skills/`. |
+| `No SKILL.md` | A skill folder holds no `SKILL.md`, so there is nothing to install. |
+| `Nested skill below a skill directory` | A `SKILL.md` below a skill's own top level: a skill hidden inside a skill. |
+| `Folder name is not ...` | The folder name does not read `hos-<name>`, and the folder name is the installed name. |
+| `Missing name:` | The frontmatter declares no `name:`. |
+| `name: does not match the folder name` | The two disagree, so a reader cannot tell which one the skill is. |
+
+The rule for a valid name is written out in this script and in the build's, rather than shared through an import, so that neither has to reach into the other's skill folder. A test pins the two copies to each other: changing the rule in one place alone fails it.
+
+## What it does not report
+
+It says nothing about a skill's content — its wording, its structure, whether its description would make an agent pick it. This is the layout keeper, not the reviewer.

--- a/.claude/skills/audit/scripts/audit.js
+++ b/.claude/skills/audit/scripts/audit.js
@@ -1,0 +1,157 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+const sourceRoot = join(repoRoot, 'kit/skills')
+const namePattern = /^hos-[a-z0-9-]{1,60}$/u
+
+/**
+ * Read the `name:` value from a SKILL.md's frontmatter.
+ *
+ * @param {string} skillMdPath - Path to the SKILL.md to read.
+ * @returns {string | null} The declared name, or null when absent or unparsable.
+ */
+function readSkillName (skillMdPath) {
+  const content = readFileSync(skillMdPath, 'utf8')
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n/u)
+
+  if (!frontmatterMatch) {
+    return null
+  }
+
+  const nameMatch = frontmatterMatch[1].match(/^name:[ \t]*(.*)$/mu)
+
+  if (!nameMatch) {
+    return null
+  }
+
+  const value = nameMatch[1]
+    .trim()
+    .replace(/^(['"])([\s\S]*)\1$/u, '$2')
+    .trim()
+
+  return value === ''
+    ? null
+    : value
+}
+
+/**
+ * Find every SKILL.md below a skill directory's own top level.
+ *
+ * @param {string} dir - Directory to search.
+ * @param {Array<string>} segments - Path segments accumulated so far, relative to the skill directory.
+ * @returns {Array<string>} Paths of nested SKILL.md files, relative to the skill directory.
+ */
+function findNestedSkillMds (
+  dir,
+  segments
+) {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter(it => it.isDirectory())
+    .flatMap(it => {
+      const entries = readdirSync(join(dir, it.name), { withFileTypes: true })
+      const nested = entries.some(entry => entry.isFile() && entry.name === 'SKILL.md')
+        ? [[...segments, it.name, 'SKILL.md'].join('/')]
+        : []
+
+      return [
+        ...nested,
+        ...findNestedSkillMds(join(dir, it.name), [...segments, it.name]),
+      ]
+    })
+}
+
+/**
+ * Read one entry directly under kit/skills/.
+ *
+ * @param {import('node:fs').Dirent} dirent - Child of kit/skills/.
+ * @returns {{folderName: string, path: string, isDirectory: boolean, hasSkillMd: boolean, name: string | null, nestedSkillMds: Array<string>}} The entry.
+ */
+function readSkillEntry (dirent) {
+  const absolutePath = join(sourceRoot, dirent.name)
+  const path = `kit/skills/${dirent.name}`
+
+  if (!dirent.isDirectory()) {
+    return {
+      folderName: dirent.name,
+      path,
+      isDirectory: false,
+      hasSkillMd: false,
+      name: null,
+      nestedSkillMds: [],
+    }
+  }
+
+  const hasSkillMd = readdirSync(absolutePath, { withFileTypes: true })
+    .some(entry => entry.isFile() && entry.name === 'SKILL.md')
+
+  return {
+    folderName: dirent.name,
+    path,
+    isDirectory: true,
+    hasSkillMd,
+    name: hasSkillMd
+      ? readSkillName(join(absolutePath, 'SKILL.md'))
+      : null,
+    nestedSkillMds: findNestedSkillMds(absolutePath, []),
+  }
+}
+
+const skillEntries = readdirSync(sourceRoot, { withFileTypes: true })
+  .map(it => readSkillEntry(it))
+
+const problemGroups = [
+  {
+    heading: 'Not a skill directory',
+    lines: skillEntries
+      .filter(it => !it.isDirectory)
+      .map(it => it.path),
+  },
+  {
+    heading: 'No SKILL.md',
+    lines: skillEntries
+      .filter(it => it.isDirectory && !it.hasSkillMd)
+      .map(it => `${it.path}/`),
+  },
+  {
+    heading: 'Nested skill below a skill directory',
+    lines: skillEntries
+      .flatMap(it => it.nestedSkillMds.map(nested => `${it.path}/${nested}`)),
+  },
+  {
+    heading: `Folder name is not ${namePattern.source}`,
+    lines: skillEntries
+      .filter(it => it.isDirectory && !namePattern.test(it.folderName))
+      .map(it => `${it.path}/`),
+  },
+  {
+    heading: 'Missing name:',
+    lines: skillEntries
+      .filter(it => it.hasSkillMd && it.name === null)
+      .map(it => `${it.path}/SKILL.md`),
+  },
+  {
+    heading: 'name: does not match the folder name',
+    lines: skillEntries
+      .filter(it => it.name !== null && it.name !== it.folderName)
+      .map(it => `${it.path}/SKILL.md  (declares ${it.name})`),
+  },
+]
+  .filter(it => it.lines.length > 0)
+
+process.stdout.write(`Checked ${skillEntries.length} skills under kit/skills/\n`)
+
+problemGroups.forEach(({ heading, lines }) => {
+  process.stdout.write(`\n${heading}: ${lines.length}\n\n`)
+
+  lines.forEach(line => {
+    process.stdout.write(`    ${line}\n`)
+  })
+})
+
+if (problemGroups.length === 0) {
+  process.stdout.write('\nNo problem found.\n')
+} else {
+  process.exitCode = 1
+}

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: build
+description: "Repository-specific build convention: kit/skills/ holds one level of skill folders named hos-*, and the build validates that tree and copies it into dist/skills/ unchanged, which is what a consuming repository installs. Use when rebuilding the dist/ output, or when adding, renaming or placing a skill under kit/skills/."
+---
+
+# Build
+
+A consuming repository installs skills as a single flat list directly under `.claude/skills/`. `kit/skills/` already has that shape here, and `dist/skills/` is the build output that ships in the package.
+
+## Source layout
+
+Every skill sits directly under `kit/skills/`, at exactly this depth:
+
+```
+kit/skills/<name>/SKILL.md
+```
+
+There is no domain directory in between. This package is one domain — support — so a folder named after it would repeat what the package name and the skill prefix already say, and every consumer of the tree would have to know about a level that carries nothing.
+
+A skill folder may hold its own subdirectories (`references/`, `scripts/`), but no `SKILL.md` below its top level: those subdirectories are the skill's own files, never more skills. There are no intermediate grouping directories.
+
+### The folder name is the skill's name
+
+A skill folder's name is the skill's `name:`, and the folder name it gets under `dist/skills/`, all one string:
+
+```
+kit/skills/hos-explain/   name: hos-explain   →   dist/skills/hos-explain/
+```
+
+The prefix is part of the name: the skill is invoked as `/hos-explain`. The `ho` stands for **hora**, from Hora Kit — the Open Reach Tech product this skill library is part of — and the third character names the library: `s` for this one, against `c` for `hora-skills-ort-core`, `r` for `hora-skills-ort-renchan` and `f` for `hora-skills-ort-furo`.
+
+Those characters buy two things. A consuming repository installs these skills side by side with its own and with the sibling libraries' — a project equips whichever libraries it works with — all in one flat list, and the prefix is what tells a reader at a glance which library a skill came from. And because every prefix belongs to exactly one library, and a filesystem cannot hold two folders of one name in one directory, no two installed skills can collide: the flat namespace is protected by the source layout itself, with nothing to check.
+
+## The build
+
+```
+node .claude/skills/build/scripts/build.js
+```
+
+It validates the whole source tree first, then deletes `dist/skills/` outright and recreates it: `dist/` is a function of the current source alone. Without the deletion, a skill renamed or removed at the source would keep its stale folder in `dist/` indefinitely, and the package would go on shipping a skill that no longer exists — a failure invisible in a diff, because nothing about the stale folder changes.
+
+Each skill folder is then copied to `dist/skills/<folder name>/` **byte for byte**. Nothing is rewritten:
+
+- The `name:` line stays. The field and the folder name are the same string by construction, so there is no second, divergent source of truth to remove.
+- No source note is appended. The prefix already names the library, so an installed `hos-explain/` says where it came from, and a footer repeating it would be text to maintain that carries nothing.
+
+Validation runs before the deletion, so a source tree that cannot produce a valid flat namespace leaves the previous output untouched rather than half-replaced. Every problem found is reported at once, not one per run:
+
+| Aborts the build | Why |
+|---|---|
+| A non-directory entry directly under `kit/skills/` | Only skill folders belong there. |
+| A skill folder with no `SKILL.md` | A skill is its `SKILL.md`; without one there is nothing to install. |
+| A `SKILL.md` below a skill folder's top level | It would be a second skill hidden inside one, invisible to the flat output. |
+| A folder name that is not `hos-<name>` | The folder name is the installed name, so an invalid one installs wrongly. |
+| A `SKILL.md` with no `name:` | The agent reads that field to know what it is running. |
+| A `name:` that differs from the folder name | Two answers to one question; the reader cannot tell which is real. |
+
+The package's `prepack` runs this build, so `npm publish` cannot ship a `dist/` that does not match `kit/`.
+
+## Adding a skill
+
+Create `kit/skills/hos-<name>/SKILL.md`, write `name: hos-<name>` in its frontmatter to match the folder, and run the build. The audit skill reports the same tree without writing anything, and CI runs it on every pull request.

--- a/.claude/skills/build/scripts/build.js
+++ b/.claude/skills/build/scripts/build.js
@@ -1,0 +1,152 @@
+import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url))
+const sourceRoot = join(repoRoot, 'kit/skills')
+const outputRoot = join(repoRoot, 'dist/skills')
+const namePattern = /^hos-[a-z0-9-]{1,60}$/u
+
+/**
+ * Read the `name:` value from a SKILL.md's frontmatter.
+ *
+ * @param {string} skillMdPath - Path to the SKILL.md to read.
+ * @returns {string | null} The declared name, or null when absent or unparsable.
+ */
+function readSkillName (skillMdPath) {
+  const content = readFileSync(skillMdPath, 'utf8')
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n/u)
+
+  if (!frontmatterMatch) {
+    return null
+  }
+
+  const nameMatch = frontmatterMatch[1].match(/^name:[ \t]*(.*)$/mu)
+
+  if (!nameMatch) {
+    return null
+  }
+
+  const value = nameMatch[1]
+    .trim()
+    .replace(/^(['"])([\s\S]*)\1$/u, '$2')
+    .trim()
+
+  return value === ''
+    ? null
+    : value
+}
+
+/**
+ * Find every SKILL.md below a skill directory's own top level.
+ *
+ * @param {string} dir - Directory to search, relative paths accumulated from it.
+ * @param {Array<string>} segments - Path segments accumulated so far, relative to the skill directory.
+ * @returns {Array<string>} Paths of nested SKILL.md files, relative to the skill directory.
+ */
+function findNestedSkillMds (
+  dir,
+  segments
+) {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter(it => it.isDirectory())
+    .flatMap(it => {
+      const entries = readdirSync(join(dir, it.name), { withFileTypes: true })
+      const nested = entries.some(entry => entry.isFile() && entry.name === 'SKILL.md')
+        ? [[...segments, it.name, 'SKILL.md'].join('/')]
+        : []
+
+      return [
+        ...nested,
+        ...findNestedSkillMds(join(dir, it.name), [...segments, it.name]),
+      ]
+    })
+}
+
+/**
+ * Read one entry directly under kit/skills/.
+ *
+ * @param {import('node:fs').Dirent} dirent - Child of kit/skills/.
+ * @returns {{folderName: string, absolutePath: string, isDirectory: boolean, hasSkillMd: boolean, name: string | null, nestedSkillMds: Array<string>}} The entry.
+ */
+function readSkillEntry (dirent) {
+  const absolutePath = join(sourceRoot, dirent.name)
+
+  if (!dirent.isDirectory()) {
+    return {
+      folderName: dirent.name,
+      absolutePath,
+      isDirectory: false,
+      hasSkillMd: false,
+      name: null,
+      nestedSkillMds: [],
+    }
+  }
+
+  const hasSkillMd = readdirSync(absolutePath, { withFileTypes: true })
+    .some(entry => entry.isFile() && entry.name === 'SKILL.md')
+
+  return {
+    folderName: dirent.name,
+    absolutePath,
+    isDirectory: true,
+    hasSkillMd,
+    name: hasSkillMd
+      ? readSkillName(join(absolutePath, 'SKILL.md'))
+      : null,
+    nestedSkillMds: findNestedSkillMds(absolutePath, []),
+  }
+}
+
+const skillEntries = readdirSync(sourceRoot, { withFileTypes: true })
+  .map(it => readSkillEntry(it))
+
+const issues = [
+  ...skillEntries
+    .filter(it => !it.isDirectory)
+    .map(it => `Not a skill directory: kit/skills/${it.folderName}`),
+
+  ...skillEntries
+    .filter(it => it.isDirectory && !it.hasSkillMd)
+    .map(it => `No SKILL.md: kit/skills/${it.folderName}/`),
+
+  ...skillEntries
+    .flatMap(it => it.nestedSkillMds
+      .map(nested => `Nested skill: kit/skills/${it.folderName}/${nested}`)),
+
+  ...skillEntries
+    .filter(it => it.isDirectory && !namePattern.test(it.folderName))
+    .map(it => `Invalid folder name: kit/skills/${it.folderName}/`),
+
+  ...skillEntries
+    .filter(it => it.hasSkillMd && it.name === null)
+    .map(it => `Missing name: kit/skills/${it.folderName}/SKILL.md`),
+
+  ...skillEntries
+    .filter(it => it.name !== null && it.name !== it.folderName)
+    .map(it => `name: ${it.name} does not match its folder: kit/skills/${it.folderName}/`),
+]
+
+if (issues.length > 0) {
+  const details = issues
+    .map(it => `  - ${it}`)
+    .join('\n')
+
+  throw new Error(
+    `Cannot build dist/skills:\n${details}\n`
+  )
+}
+
+rmSync(outputRoot, { recursive: true, force: true })
+
+mkdirSync(outputRoot, { recursive: true })
+
+skillEntries.forEach(({ absolutePath, folderName }) => {
+  cpSync(
+    absolutePath,
+    join(outputRoot, folderName),
+    { recursive: true }
+  )
+})
+
+process.stdout.write(`Built ${skillEntries.length} skills into ${outputRoot}\n`)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "l": "npm run lint",
     "lint": "eslint .",
     "prepack": "npm run build",
+    "skill-names": "node .claude/skills/audit/scripts/audit.js",
     "test": "export NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\"; export NODE_ENV=development; jest"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Distributes the ORT support skills used to develop with Hora Kit.",
   "type": "module",
   "files": [
-    "lib/",
-    "types/",
-    "!types/env/**"
+    "dist/",
+    "docs/",
+    "lib/"
   ],
   "keywords": [
     "hora",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "support"
   ],
   "scripts": {
+    "build": "node .claude/skills/build/scripts/build.js",
     "l": "npm run lint",
     "lint": "eslint .",
     "test": "export NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\"; export NODE_ENV=development; jest"

--- a/package.json
+++ b/package.json
@@ -3,13 +3,11 @@
   "version": "0.0.0",
   "description": "Distributes the ORT support skills used to develop with Hora Kit.",
   "type": "module",
-  "main": "index.js",
   "files": [
     "lib/",
     "types/",
     "!types/env/**"
   ],
-  "types": "./types/index.d.ts",
   "keywords": [
     "hora",
     "hora-kit",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "node .claude/skills/build/scripts/build.js",
     "l": "npm run lint",
     "lint": "eslint .",
+    "prepack": "npm run build",
     "test": "export NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\"; export NODE_ENV=development; jest"
   },
   "repository": {

--- a/tests/__tests__/skills/name-pattern.js
+++ b/tests/__tests__/skills/name-pattern.js
@@ -1,0 +1,32 @@
+import {
+  readFileSync,
+} from 'node:fs'
+import {
+  join,
+} from 'node:path'
+import {
+  fileURLToPath,
+} from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url))
+
+/*
+ * The rule for a valid skill name is written out in both scripts on purpose, so
+ * that neither skill's script has to import from the other's. This pins the two
+ * copies to one another: changing the rule in one place alone fails here.
+ */
+describe('Skill name pattern', () => {
+  describe('is declared identically by every script that enforces it', () => {
+    const cases = [
+      { scriptPath: '.claude/skills/audit/scripts/audit.js' },
+      { scriptPath: '.claude/skills/build/scripts/build.js' },
+    ]
+
+    test.each(cases)('$scriptPath', ({ scriptPath }) => {
+      const content = readFileSync(join(repoRoot, scriptPath), 'utf8')
+
+      expect(content)
+        .toContain('const namePattern = /^hos-[a-z0-9-]{1,60}$/u')
+    })
+  })
+})


### PR DESCRIPTION
# Why

* Close #9

# How

* Adds the two maintenance skills this package needs: the build that writes `dist/skills/`, and the audit that reports the same tree without writing. Both are migrated from `hora-skills`, and both come out considerably smaller here
* **No domain map, and no domain checks.** The three sibling packages carry a `DOMAIN_PREFIX` table, a missing-domain guard and a "wrong prefix for this domain" rule — machinery that exists only to police the domain directory. There is none here, so the build reads `kit/skills/*` directly and the checks that remain are the ones that are true of any skill: it is a directory, it has a `SKILL.md`, it hides no second skill, its folder name reads `hos-<name>`, and its `name:` says the same
* **The skill is called `build`, not `flatten`.** Flattening was the whole of the build when there was a domain level to drop; with the flat layout there is nothing to flatten, and a name that describes an operation the script no longer performs would send the next reader looking for it. Happy to rename it back if the same command name across the four packages matters more
* `package.json` gains `build`, `prepack` and `skill-names`, and `files` becomes `dist/`, `docs/`, `lib/`. The template pointed `main` and `types` at an `index.js` and a `types/index.d.ts` that this package has no reason to carry, so both are dropped: what ships is the built skills
* `tests/__tests__/skills/name-pattern.js` pins the name rule in both scripts to each other. The siblings also carry `domain-prefix.js` for the domain table; with no table, that test has nothing left to pin and is not migrated
* Verified locally: the build writes `dist/skills/hos-explain/` and `dist/skills/hos-user-manual/`, and the audit reports `Checked 2 skills under kit/skills/` with no problem
