### PR TITLE
🏷️ Check the skill names in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,6 @@ jobs:
         env:
           NODE_ENV: development
         run: npm test
+
+      - name: 🏷️ Skill names
+        run: npm run skill-names


### PR DESCRIPTION
# Why

* Close #17

# How

* Runs the audit added in #9 on every pull request, as the three sibling packages do. Without it, a skill whose folder name or `name:` drifts is only caught by whoever happens to run the build
* It is a step of its own rather than part of the Jest run: what it reports is the layout of `kit/skills/`, not a test of this package`s code, and its output is the list of problems rather than a pass or fail line
