### PR TITLE
🔗 Check the document links under `kit/`

### DIFF
--- a/tests/__tests__/skills/document-links.js
+++ b/tests/__tests__/skills/document-links.js
@@ -1,0 +1,36 @@
+import {
+  fileURLToPath,
+} from 'node:url'
+
+import MarkdownDocumentCatalog from '../../tools/MarkdownDocumentCatalog.js'
+
+/*
+ * Markdown links inside kit/ are checked here because nothing else does: lint
+ * never opens a .md file, and the name audit only compares directory names.
+ * A section renamed without its links repointed therefore ships silently, and
+ * has done — the change that added this test repaired 32 links already broken.
+ *
+ * dist/ is a verbatim copy made by the build, so checking kit/ covers
+ * what is published.
+ */
+describe('Documents under kit/', () => {
+  describe('should hold no link that resolves to nothing', () => {
+    const rootPath = fileURLToPath(new URL('../../../kit/', import.meta.url))
+
+    const catalog = MarkdownDocumentCatalog.create({
+      rootPath,
+    })
+
+    const cases = catalog.collectLinkingDocumentPaths()
+
+    test.each(cases)('%s', documentPath => {
+      const received = catalog.buildDocument({
+        documentPath,
+      })
+        .collectBrokenLinkTargets()
+
+      expect(received)
+        .toEqual([])
+    })
+  })
+})

--- a/tests/__tests__/test-tools/MarkdownDocument.js
+++ b/tests/__tests__/test-tools/MarkdownDocument.js
@@ -1,0 +1,605 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  fileURLToPath,
+} from 'node:url'
+
+import MarkdownDocument from '../../tools/MarkdownDocument.js'
+
+describe('MarkdownDocument', () => {
+  describe('constructor', () => {
+    describe('should keep property', () => {
+      describe('#filePath', () => {
+        const cases = [
+          {
+            input: {
+              filePath: '/alpha/beta.md',
+              markdown: '# Beta\n',
+            },
+            expected: '/alpha/beta.md',
+          },
+          {
+            input: {
+              filePath: '/gamma/delta/epsilon.md',
+              markdown: '# Epsilon\n',
+            },
+            expected: '/gamma/delta/epsilon.md',
+          },
+        ]
+
+        test.each(cases)('filePath: $input.filePath', ({ input, expected }) => {
+          const markdownDocument = new MarkdownDocument(input)
+
+          expect(markdownDocument)
+            .toHaveProperty('filePath', expected)
+        })
+      })
+
+      describe('#markdown', () => {
+        const cases = [
+          {
+            input: {
+              filePath: '/alpha/beta.md',
+              markdown: '# Beta\n',
+            },
+            expected: '# Beta\n',
+          },
+          {
+            input: {
+              filePath: '/alpha/beta.md',
+              markdown: '# Beta\n\n[gamma](./gamma.md)\n',
+            },
+            expected: '# Beta\n\n[gamma](./gamma.md)\n',
+          },
+          {
+            input: {
+              filePath: '/alpha/beta.md',
+              markdown: '',
+            },
+            expected: '',
+          },
+        ]
+
+        test.each(cases)('markdown: $input.markdown', ({ input, expected }) => {
+          const markdownDocument = new MarkdownDocument(input)
+
+          expect(markdownDocument)
+            .toHaveProperty('markdown', expected)
+        })
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('.create()', () => {
+    describe('should be an instance of own class', () => {
+      const cases = [
+        {
+          input: {
+            filePath: '/alpha/beta.md',
+            markdown: '# Beta\n',
+          },
+        },
+        {
+          input: {
+            filePath: '/gamma/delta.md',
+            markdown: '',
+          },
+        },
+      ]
+
+      test.each(cases)('filePath: $input.filePath', ({ input }) => {
+        const received = MarkdownDocument.create(input)
+
+        expect(received)
+          .toBeInstanceOf(MarkdownDocument)
+      })
+    })
+
+    describe('should call constructor', () => {
+      const cases = [
+        {
+          tally: {
+            filePath: '/alpha/beta.md',
+            markdown: '# Beta\n',
+          },
+        },
+        {
+          tally: {
+            filePath: '/gamma/delta.md',
+            markdown: '# Delta\n',
+          },
+        },
+      ]
+
+      test.each(cases)('filePath: $tally.filePath', ({ tally }) => {
+        const SpyClass = constructorSpy.spyOn(MarkdownDocument)
+
+        SpyClass.create(tally)
+
+        expect(SpyClass.__spy__)
+          .toHaveBeenCalledWith(tally)
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('.buildSlug()', () => {
+    describe('should build the anchor slug of the heading', () => {
+      const cases = [
+        {
+          input: {
+            heading: 'Alpha',
+          },
+          expected: 'alpha',
+        },
+        {
+          input: {
+            heading: 'Alpha Beta Gamma',
+          },
+          expected: 'alpha-beta-gamma',
+        },
+        {
+          input: {
+            heading: 'describe() Structure',
+          },
+          expected: 'describe-structure',
+        },
+        {
+          input: {
+            heading: '1. Placement & execution order', // a run of spaces is left uncollapsed
+          },
+          expected: '1-placement--execution-order',
+        },
+        {
+          input: {
+            heading: 'Write any as `*`', // the tail is left untrimmed
+          },
+          expected: 'write-any-as-',
+        },
+        {
+          input: {
+            heading: 'snake_case and dash-case', // `_` and `-` survive
+          },
+          expected: 'snake_case-and-dash-case',
+        },
+        {
+          input: {
+            heading: '日本語の見出し', // a letter of any script survives
+          },
+          expected: '日本語の見出し',
+        },
+      ]
+
+      test.each(cases)('heading: $input.heading', ({ input, expected }) => {
+        const received = MarkdownDocument.buildSlug(input)
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('#get:Ctor', () => {
+    describe('should be the constructor of the instance', () => {
+      test('when instantiated as is', () => {
+        const markdownDocument = MarkdownDocument.create({
+          filePath: '/alpha/beta.md',
+          markdown: '# Beta\n',
+        })
+
+        const received = markdownDocument.Ctor
+
+        expect(received)
+          .toBe(MarkdownDocument) // same reference
+      })
+
+      test('when instantiated as a derived class', () => {
+        class DerivedMarkdownDocument extends MarkdownDocument {}
+
+        const markdownDocument = DerivedMarkdownDocument.create({
+          filePath: '/alpha/beta.md',
+          markdown: '# Beta\n',
+        })
+
+        const received = markdownDocument.Ctor
+
+        expect(received)
+          .toBe(DerivedMarkdownDocument) // same reference
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('#get:fs', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const markdownDocument = MarkdownDocument.create({
+          filePath: '/alpha/beta.md',
+          markdown: '# Beta\n',
+        })
+
+        const received = markdownDocument.fs
+
+        expect(received)
+          .toBe(fs) // same reference
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('#get:path', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const markdownDocument = MarkdownDocument.create({
+          filePath: '/alpha/beta.md',
+          markdown: '# Beta\n',
+        })
+
+        const received = markdownDocument.path
+
+        expect(received)
+          .toBe(path) // same reference
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('#buildTextOutsideFencedCode()', () => {
+    describe('should drop the fenced code blocks', () => {
+      const cases = [
+        {
+          input: {
+            markdown: '# Alpha\n\n[beta](./beta.md)\n', // no fence at all
+          },
+          expected: '# Alpha\n\n[beta](./beta.md)\n',
+        },
+        {
+          input: {
+            markdown: '[alpha](./alpha.md)\n\n```md\n[beta](./beta.md)\n```\n',
+          },
+          expected: '[alpha](./alpha.md)\n\n\n',
+        },
+        {
+          input: {
+            markdown: '# Alpha\n\n```\n# Beta\n```\n', // a heading inside a fence goes too
+          },
+          expected: '# Alpha\n\n\n',
+        },
+        {
+          input: {
+            markdown: '```\n[alpha](./alpha.md)\n```\n\n[beta](./beta.md)\n\n```\n[gamma](./gamma.md)\n```\n',
+          },
+          expected: '\n\n[beta](./beta.md)\n\n\n',
+        },
+        {
+          input: {
+            markdown: '',
+          },
+          expected: '',
+        },
+      ]
+
+      test.each(cases)('markdown: $input.markdown', ({ input, expected }) => {
+        const markdownDocument = MarkdownDocument.create({
+          filePath: '/alpha/beta.md', // neutral value; not under test
+          markdown: input.markdown,
+        })
+
+        const received = markdownDocument.buildTextOutsideFencedCode()
+
+        expect(received)
+          .toBe(expected)
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('#collectHeadingSlugs()', () => {
+    describe('should collect the slug of every heading', () => {
+      const cases = [
+        {
+          input: {
+            markdown: '# Alpha\n',
+          },
+          expected: [
+            'alpha',
+          ],
+        },
+        {
+          input: {
+            markdown: '# Alpha\n\n## Beta heading\n\n###### Gamma\n',
+          },
+          expected: [
+            'alpha',
+            'beta-heading',
+            'gamma',
+          ],
+        },
+        {
+          input: {
+            markdown: '# Alpha   \n', // the trailing run of spaces is not part of the heading
+          },
+          expected: [
+            'alpha',
+          ],
+        },
+        {
+          input: {
+            markdown: '# Alpha\n\n```\n# Beta\n```\n', // a heading inside a fence offers no anchor
+          },
+          expected: [
+            'alpha',
+          ],
+        },
+        {
+          input: {
+            markdown: '#NoSpace\n', // a hash run without a space is not a heading
+          },
+          expected: [],
+        },
+        {
+          input: {
+            markdown: 'Alpha holds no heading.\n',
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('markdown: $input.markdown', ({ input, expected }) => {
+        const markdownDocument = MarkdownDocument.create({
+          filePath: '/alpha/beta.md', // neutral value; not under test
+          markdown: input.markdown,
+        })
+
+        const received = markdownDocument.collectHeadingSlugs()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('#collectLinkTargets()', () => {
+    describe('should collect the targets that must resolve in this repository', () => {
+      const cases = [
+        {
+          input: {
+            markdown: '[alpha](./alpha.md)\n',
+          },
+          expected: [
+            './alpha.md',
+          ],
+        },
+        {
+          input: {
+            markdown: '[alpha](./alpha.md#beta)\n[gamma](#delta)\n',
+          },
+          expected: [
+            './alpha.md#beta',
+            '#delta',
+          ],
+        },
+        {
+          input: {
+            markdown: '[alpha](./alpha.md)\n\n```\n[beta](./beta.md)\n```\n', // a target inside a fence is an example
+          },
+          expected: [
+            './alpha.md',
+          ],
+        },
+        {
+          input: {
+            markdown: 'Alpha holds no link.\n',
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('markdown: $input.markdown', ({ input, expected }) => {
+        const markdownDocument = MarkdownDocument.create({
+          filePath: '/alpha/beta.md', // neutral value; not under test
+          markdown: input.markdown,
+        })
+
+        const received = markdownDocument.collectLinkTargets()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+
+    describe('should exclude the targets outside this repository', () => {
+      const cases = [
+        {
+          input: {
+            markdown: '[alpha](https://example.com/alpha)\n',
+          },
+        },
+        {
+          input: {
+            markdown: '[alpha](http://example.com/alpha)\n',
+          },
+        },
+        {
+          input: {
+            markdown: '[alpha](mailto:alpha@example.com)\n',
+          },
+        },
+      ]
+
+      test.each(cases)('markdown: $input.markdown', ({ input }) => {
+        const markdownDocument = MarkdownDocument.create({
+          filePath: '/alpha/beta.md', // neutral value; not under test
+          markdown: input.markdown,
+        })
+
+        const received = markdownDocument.collectLinkTargets()
+
+        expect(received)
+          .toEqual([])
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('#resolvesLinkTarget()', () => {
+    const filePath = fileURLToPath(new URL('../../fixtures/document-links/alpha.md', import.meta.url))
+
+    const markdown = '# Alpha\n\n## Existing heading\n'
+
+    describe('should resolve the target', () => {
+      const cases = [
+        {
+          input: {
+            target: '#existing-heading', // a heading of the linking document itself
+          },
+        },
+        {
+          input: {
+            target: './beta.md',
+          },
+        },
+        {
+          input: {
+            target: './beta.md#existing-heading',
+          },
+        },
+        {
+          input: {
+            target: './nested/gamma.md#gamma',
+          },
+        },
+        {
+          input: {
+            target: '../document-links/beta.md',
+          },
+        },
+        {
+          input: {
+            target: './delta.txt#anything', // no heading is read out of a file that is not Markdown
+          },
+        },
+      ]
+
+      test.each(cases)('target: $input.target', ({ input }) => {
+        const markdownDocument = MarkdownDocument.create({
+          filePath,
+          markdown,
+        })
+
+        const received = markdownDocument.resolvesLinkTarget(input)
+
+        expect(received)
+          .toBe(true)
+      })
+    })
+
+    describe('should not resolve the target', () => {
+      const cases = [
+        {
+          input: {
+            target: '#missing-heading',
+          },
+        },
+        {
+          input: {
+            target: './missing.md',
+          },
+        },
+        {
+          input: {
+            target: './beta.md#missing-heading',
+          },
+        },
+        {
+          input: {
+            target: '../missing-directory/beta.md',
+          },
+        },
+      ]
+
+      test.each(cases)('target: $input.target', ({ input }) => {
+        const markdownDocument = MarkdownDocument.create({
+          filePath,
+          markdown,
+        })
+
+        const received = markdownDocument.resolvesLinkTarget(input)
+
+        expect(received)
+          .toBe(false)
+      })
+    })
+  })
+})
+
+describe('MarkdownDocument', () => {
+  describe('#collectBrokenLinkTargets()', () => {
+    describe('should collect the targets that resolve to nothing', () => {
+      const cases = [
+        {
+          input: {
+            markdown: '# Alpha\n\n## Existing heading\n\n[alpha](#existing-heading)\n[beta](#missing-heading)\n',
+          },
+          expected: [
+            '#missing-heading',
+          ],
+        },
+        {
+          input: {
+            markdown: '[alpha](./beta.md)\n[gamma](./missing.md)\n',
+          },
+          expected: [
+            './missing.md',
+          ],
+        },
+        {
+          input: {
+            markdown: '[alpha](./beta.md#existing-heading)\n[gamma](./beta.md#missing-heading)\n',
+          },
+          expected: [
+            './beta.md#missing-heading',
+          ],
+        },
+        {
+          input: {
+            markdown: '[alpha](./beta.md)\n[gamma](https://example.com/gamma)\n',
+          },
+          expected: [],
+        },
+        {
+          input: {
+            markdown: 'Alpha holds no link.\n',
+          },
+          expected: [],
+        },
+      ]
+
+      test.each(cases)('markdown: $input.markdown', ({ input, expected }) => {
+        const filePath = fileURLToPath(new URL('../../fixtures/document-links/alpha.md', import.meta.url))
+
+        const markdownDocument = MarkdownDocument.create({
+          filePath,
+          markdown: input.markdown,
+        })
+
+        const received = markdownDocument.collectBrokenLinkTargets()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})

--- a/tests/__tests__/test-tools/MarkdownDocumentCatalog.js
+++ b/tests/__tests__/test-tools/MarkdownDocumentCatalog.js
@@ -1,0 +1,341 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  fileURLToPath,
+} from 'node:url'
+
+import MarkdownDocumentCatalog from '../../tools/MarkdownDocumentCatalog.js'
+
+import MarkdownDocument from '../../tools/MarkdownDocument.js'
+
+describe('MarkdownDocumentCatalog', () => {
+  describe('constructor', () => {
+    describe('should keep property', () => {
+      describe('#rootPath', () => {
+        const cases = [
+          {
+            input: {
+              rootPath: '/alpha/beta',
+            },
+            expected: '/alpha/beta',
+          },
+          {
+            input: {
+              rootPath: '/gamma',
+            },
+            expected: '/gamma',
+          },
+        ]
+
+        test.each(cases)('rootPath: $input.rootPath', ({ input, expected }) => {
+          const catalog = new MarkdownDocumentCatalog(input)
+
+          expect(catalog)
+            .toHaveProperty('rootPath', expected)
+        })
+      })
+    })
+  })
+})
+
+describe('MarkdownDocumentCatalog', () => {
+  describe('.create()', () => {
+    describe('should be an instance of own class', () => {
+      const cases = [
+        {
+          input: {
+            rootPath: '/alpha/beta',
+          },
+        },
+        {
+          input: {
+            rootPath: '/gamma',
+          },
+        },
+      ]
+
+      test.each(cases)('rootPath: $input.rootPath', ({ input }) => {
+        const received = MarkdownDocumentCatalog.create(input)
+
+        expect(received)
+          .toBeInstanceOf(MarkdownDocumentCatalog)
+      })
+    })
+
+    describe('should call constructor', () => {
+      const cases = [
+        {
+          tally: {
+            rootPath: '/alpha/beta',
+          },
+        },
+        {
+          tally: {
+            rootPath: '/gamma',
+          },
+        },
+      ]
+
+      test.each(cases)('rootPath: $tally.rootPath', ({ tally }) => {
+        const SpyClass = constructorSpy.spyOn(MarkdownDocumentCatalog)
+
+        SpyClass.create(tally)
+
+        expect(SpyClass.__spy__)
+          .toHaveBeenCalledWith(tally)
+      })
+    })
+  })
+})
+
+describe('MarkdownDocumentCatalog', () => {
+  describe('.get:MarkdownDocumentCtor', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const received = MarkdownDocumentCatalog.MarkdownDocumentCtor
+
+        expect(received)
+          .toBe(MarkdownDocument) // same reference
+      })
+    })
+  })
+})
+
+describe('MarkdownDocumentCatalog', () => {
+  describe('#get:Ctor', () => {
+    describe('should be the constructor of the instance', () => {
+      test('when instantiated as is', () => {
+        const catalog = MarkdownDocumentCatalog.create({
+          rootPath: '/alpha/beta',
+        })
+
+        const received = catalog.Ctor
+
+        expect(received)
+          .toBe(MarkdownDocumentCatalog) // same reference
+      })
+
+      test('when instantiated as a derived class', () => {
+        class DerivedMarkdownDocumentCatalog extends MarkdownDocumentCatalog {}
+
+        const catalog = DerivedMarkdownDocumentCatalog.create({
+          rootPath: '/alpha/beta',
+        })
+
+        const received = catalog.Ctor
+
+        expect(received)
+          .toBe(DerivedMarkdownDocumentCatalog) // same reference
+      })
+    })
+  })
+})
+
+describe('MarkdownDocumentCatalog', () => {
+  describe('#get:fs', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const catalog = MarkdownDocumentCatalog.create({
+          rootPath: '/alpha/beta',
+        })
+
+        const received = catalog.fs
+
+        expect(received)
+          .toBe(fs) // same reference
+      })
+    })
+  })
+})
+
+describe('MarkdownDocumentCatalog', () => {
+  describe('#get:path', () => {
+    describe('when called as is', () => {
+      test('should be fixed value', () => {
+        const catalog = MarkdownDocumentCatalog.create({
+          rootPath: '/alpha/beta',
+        })
+
+        const received = catalog.path
+
+        expect(received)
+          .toBe(path) // same reference
+      })
+    })
+  })
+})
+
+describe('MarkdownDocumentCatalog', () => {
+  describe('#collectDocumentPaths()', () => {
+    describe('should collect every Markdown document under the root', () => {
+      const cases = [
+        {
+          input: {
+            rootUrl: '../../fixtures/document-links/',
+          },
+          expected: [
+            'alpha.md',
+            'beta.md',
+            'nested/gamma.md', // a document of a subdirectory is named in POSIX notation
+          ],
+        },
+        {
+          input: {
+            rootUrl: '../../fixtures/document-links/nested/',
+          },
+          expected: [
+            'gamma.md',
+          ],
+        },
+      ]
+
+      test.each(cases)('rootUrl: $input.rootUrl', ({ input, expected }) => {
+        const rootPath = fileURLToPath(new URL(input.rootUrl, import.meta.url))
+
+        const catalog = MarkdownDocumentCatalog.create({
+          rootPath,
+        })
+
+        const received = catalog.collectDocumentPaths()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('MarkdownDocumentCatalog', () => {
+  describe('#collectLinkingDocumentPaths()', () => {
+    describe('should collect only the documents that hold a link', () => {
+      const cases = [
+        {
+          input: {
+            rootUrl: '../../fixtures/document-links/', // beta.md holds no link, so it is left out
+          },
+          expected: [
+            'alpha.md',
+            'nested/gamma.md',
+          ],
+        },
+        {
+          input: {
+            rootUrl: '../../fixtures/document-links/nested/',
+          },
+          expected: [
+            'gamma.md',
+          ],
+        },
+      ]
+
+      test.each(cases)('rootUrl: $input.rootUrl', ({ input, expected }) => {
+        const rootPath = fileURLToPath(new URL(input.rootUrl, import.meta.url))
+
+        const catalog = MarkdownDocumentCatalog.create({
+          rootPath,
+        })
+
+        const received = catalog.collectLinkingDocumentPaths()
+
+        expect(received)
+          .toEqual(expected)
+      })
+    })
+  })
+})
+
+describe('MarkdownDocumentCatalog', () => {
+  describe('#buildDocument()', () => {
+    describe('should be an instance of the document class', () => {
+      const cases = [
+        {
+          input: {
+            documentPath: 'beta.md',
+          },
+        },
+        {
+          input: {
+            documentPath: 'nested/gamma.md',
+          },
+        },
+      ]
+
+      test.each(cases)('documentPath: $input.documentPath', ({ input }) => {
+        const rootPath = fileURLToPath(new URL('../../fixtures/document-links/', import.meta.url))
+
+        const catalog = MarkdownDocumentCatalog.create({
+          rootPath,
+        })
+
+        const received = catalog.buildDocument(input)
+
+        expect(received)
+          .toBeInstanceOf(MarkdownDocument)
+      })
+    })
+
+    describe('should keep the path of the document', () => {
+      const cases = [
+        {
+          input: {
+            documentPath: 'beta.md',
+          },
+          expected: {
+            fileUrl: '../../fixtures/document-links/beta.md',
+          },
+        },
+        {
+          input: {
+            documentPath: 'nested/gamma.md',
+          },
+          expected: {
+            fileUrl: '../../fixtures/document-links/nested/gamma.md',
+          },
+        },
+      ]
+
+      test.each(cases)('documentPath: $input.documentPath', ({ input, expected }) => {
+        const rootPath = fileURLToPath(new URL('../../fixtures/document-links/', import.meta.url))
+
+        const catalog = MarkdownDocumentCatalog.create({
+          rootPath,
+        })
+
+        const received = catalog.buildDocument(input)
+
+        expect(received)
+          .toHaveProperty('filePath', fileURLToPath(new URL(expected.fileUrl, import.meta.url)))
+      })
+    })
+
+    describe('should read the document off the disk', () => {
+      const cases = [
+        {
+          input: {
+            documentPath: 'beta.md',
+          },
+          expected: '# Beta\n\n## Existing heading\n\nBeta holds no link of its own.\n',
+        },
+        {
+          input: {
+            documentPath: 'nested/gamma.md',
+          },
+          expected: '# Gamma\n\n- [alpha](../alpha.md)\n',
+        },
+      ]
+
+      test.each(cases)('documentPath: $input.documentPath', ({ input, expected }) => {
+        const rootPath = fileURLToPath(new URL('../../fixtures/document-links/', import.meta.url))
+
+        const catalog = MarkdownDocumentCatalog.create({
+          rootPath,
+        })
+
+        const received = catalog.buildDocument(input)
+
+        expect(received)
+          .toHaveProperty('markdown', expected)
+      })
+    })
+  })
+})

--- a/tests/fixtures/document-links/alpha.md
+++ b/tests/fixtures/document-links/alpha.md
@@ -1,0 +1,16 @@
+# Alpha
+
+## Existing heading
+
+- [own heading](#existing-heading)
+- [missing own heading](#missing-heading)
+- [sibling document](./beta.md)
+- [missing document](./missing.md)
+- [sibling heading](./beta.md#existing-heading)
+- [missing sibling heading](./beta.md#missing-heading)
+- [plain file](./delta.txt)
+- [external site](https://example.com/alpha)
+
+```md
+- [target inside a fenced block](./missing-in-fenced-code.md)
+```

--- a/tests/fixtures/document-links/beta.md
+++ b/tests/fixtures/document-links/beta.md
@@ -1,0 +1,5 @@
+# Beta
+
+## Existing heading
+
+Beta holds no link of its own.

--- a/tests/fixtures/document-links/delta.txt
+++ b/tests/fixtures/document-links/delta.txt
@@ -1,0 +1,1 @@
+Delta is not a Markdown document.

--- a/tests/fixtures/document-links/nested/gamma.md
+++ b/tests/fixtures/document-links/nested/gamma.md
@@ -1,0 +1,3 @@
+# Gamma
+
+- [alpha](../alpha.md)

--- a/tests/tools/MarkdownDocument.js
+++ b/tests/tools/MarkdownDocument.js
@@ -1,0 +1,194 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * One Markdown document, and the links written in it.
+ *
+ * A link has two halves — the file it points at, and the heading inside that file —
+ * and a document is sound only when both halves of every link resolve. The heading
+ * half is matched against the anchor slug GitHub derives from the heading text.
+ */
+export default class MarkdownDocument {
+  /**
+   * Constructor.
+   *
+   * @param {{
+   *   filePath: string
+   *   markdown: string
+   * }} params - Parameters.
+   */
+  constructor ({
+    filePath,
+    markdown,
+  }) {
+    this.filePath = filePath
+    this.markdown = markdown
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof MarkdownDocument ? X : never} T, X
+   * @param {{
+   *   filePath: string
+   *   markdown: string
+   * }} params - Parameters for the factory method.
+   * @returns {InstanceType<T>} Instance of this class.
+   * @this {T}
+   * @public
+   */
+  static create ({
+    filePath,
+    markdown,
+  }) {
+    return new this({
+      filePath,
+      markdown,
+    })
+  }
+
+  /**
+   * Build the anchor slug GitHub gives a heading.
+   *
+   * Runs of spaces are **not** collapsed and the result is **not** trimmed:
+   * `## 1. Placement & execution order` slugs to `1-placement--execution-order`,
+   * and `` ## Write any as `*` `` to `write-any-as-`. Collapsing or trimming
+   * reports links that are in fact correct as broken.
+   *
+   * @param {{
+   *   heading: string
+   * }} params - Parameters.
+   * @returns {string} Anchor slug the heading offers.
+   * @public
+   */
+  static buildSlug ({
+    heading,
+  }) {
+    return heading
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N} _-]/gu, '')
+      .replace(/ /gu, '-')
+  }
+
+  /**
+   * Constructor of this instance.
+   *
+   * @returns {typeof MarkdownDocument} Constructor of this instance.
+   */
+  get Ctor () {
+    return /** @type {typeof MarkdownDocument} */ (this.constructor)
+  }
+
+  /**
+   * Node file system module.
+   *
+   * @returns {typeof fs} Node file system module.
+   */
+  get fs () {
+    return fs
+  }
+
+  /**
+   * Node path module.
+   *
+   * @returns {typeof path} Node path module.
+   */
+  get path () {
+    return path
+  }
+
+  /**
+   * Build the document text with its fenced code blocks dropped.
+   *
+   * A link shown as an example inside a fenced block points at nothing on purpose,
+   * so it is never resolved.
+   *
+   * @returns {string} Document text outside fenced code blocks.
+   * @public
+   */
+  buildTextOutsideFencedCode () {
+    return this.markdown
+      .replace(/^```[\s\S]*?^```/gmu, '')
+  }
+
+  /**
+   * Collect the anchor slug of every heading this document offers.
+   *
+   * @returns {Array<string>} Slugs this document offers.
+   * @public
+   */
+  collectHeadingSlugs () {
+    const headings = this.buildTextOutsideFencedCode()
+      .matchAll(/^#{1,6}\s+(.+?)\s*$/gmu)
+
+    return [...headings]
+      .map(([, heading]) => this.Ctor.buildSlug({
+        heading,
+      }))
+  }
+
+  /**
+   * Collect every link target of this document that must resolve inside this repository.
+   *
+   * @returns {Array<string>} Targets as written, external URLs excluded.
+   * @public
+   */
+  collectLinkTargets () {
+    const links = this.buildTextOutsideFencedCode()
+      .matchAll(/\[[^\]]*\]\(([^)\s]+)\)/gu)
+
+    return [...links]
+      .map(([, target]) => target)
+      .filter(target => !/^(?:https?|mailto):/u.test(target))
+  }
+
+  /**
+   * Tell whether one link target resolves to a file and a heading that exist.
+   *
+   * @param {{
+   *   target: string
+   * }} params - Parameters.
+   * @returns {boolean} Whether the target resolves.
+   * @public
+   */
+  resolvesLinkTarget ({
+    target,
+  }) {
+    const [linkPath, anchor] = target.split('#')
+
+    if (!linkPath) {
+      return this.collectHeadingSlugs()
+        .includes(anchor)
+    }
+
+    const targetPath = this.path.resolve(this.filePath, '..', linkPath)
+
+    if (!this.fs.existsSync(targetPath)) {
+      return false
+    }
+
+    if (!anchor || !targetPath.endsWith('.md')) {
+      return true
+    }
+
+    return this.Ctor.create({
+      filePath: targetPath,
+      markdown: this.fs.readFileSync(targetPath, 'utf8'),
+    })
+      .collectHeadingSlugs()
+      .includes(anchor)
+  }
+
+  /**
+   * Collect every link target of this document that resolves to nothing.
+   *
+   * @returns {Array<string>} Targets that resolve to nothing.
+   * @public
+   */
+  collectBrokenLinkTargets () {
+    return this.collectLinkTargets()
+      .filter(target => !this.resolvesLinkTarget({
+        target,
+      }))
+  }
+}

--- a/tests/tools/MarkdownDocumentCatalog.js
+++ b/tests/tools/MarkdownDocumentCatalog.js
@@ -1,0 +1,133 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import MarkdownDocument from './MarkdownDocument.js'
+
+/**
+ * The Markdown documents held under one directory.
+ *
+ * A document is addressed by its path relative to the root, in POSIX notation, so
+ * that the name a test case carries reads the same on every platform.
+ */
+export default class MarkdownDocumentCatalog {
+  /**
+   * Constructor.
+   *
+   * @param {{
+   *   rootPath: string
+   * }} params - Parameters.
+   */
+  constructor ({
+    rootPath,
+  }) {
+    this.rootPath = rootPath
+  }
+
+  /**
+   * Factory method.
+   *
+   * @template {X extends typeof MarkdownDocumentCatalog ? X : never} T, X
+   * @param {{
+   *   rootPath: string
+   * }} params - Parameters for the factory method.
+   * @returns {InstanceType<T>} Instance of this class.
+   * @this {T}
+   * @public
+   */
+  static create ({
+    rootPath,
+  }) {
+    return new this({
+      rootPath,
+    })
+  }
+
+  /**
+   * Constructor of the document class this catalog builds.
+   *
+   * @returns {typeof MarkdownDocument} Constructor of the document class.
+   */
+  static get MarkdownDocumentCtor () {
+    return MarkdownDocument
+  }
+
+  /**
+   * Constructor of this instance.
+   *
+   * @returns {typeof MarkdownDocumentCatalog} Constructor of this instance.
+   */
+  get Ctor () {
+    return /** @type {typeof MarkdownDocumentCatalog} */ (this.constructor)
+  }
+
+  /**
+   * Node file system module.
+   *
+   * @returns {typeof fs} Node file system module.
+   */
+  get fs () {
+    return fs
+  }
+
+  /**
+   * Node path module.
+   *
+   * @returns {typeof path} Node path module.
+   */
+  get path () {
+    return path
+  }
+
+  /**
+   * Collect the path of every Markdown document under the root, relative to it.
+   *
+   * @returns {Array<string>} Paths in POSIX notation, in ascending order.
+   * @public
+   */
+  collectDocumentPaths () {
+    return this.fs.readdirSync(this.rootPath, {
+      recursive: true,
+    })
+      .map(entry =>
+        String(entry)
+          .replaceAll('\\', '/')
+      )
+      .filter(entry => entry.endsWith('.md'))
+      .toSorted()
+  }
+
+  /**
+   * Collect the path of every document that holds at least one link to resolve.
+   *
+   * @returns {Array<string>} Paths in POSIX notation, in ascending order.
+   * @public
+   */
+  collectLinkingDocumentPaths () {
+    return this.collectDocumentPaths()
+      .filter(documentPath =>
+        this.buildDocument({ documentPath })
+          .collectLinkTargets()
+          .length > 0
+      )
+  }
+
+  /**
+   * Build the document sitting at one path.
+   *
+   * @param {{
+   *   documentPath: string
+   * }} params - Parameters.
+   * @returns {MarkdownDocument} Document read from the root.
+   * @public
+   */
+  buildDocument ({
+    documentPath,
+  }) {
+    const filePath = this.path.join(this.rootPath, documentPath)
+
+    return this.Ctor.MarkdownDocumentCtor.create({
+      filePath,
+      markdown: this.fs.readFileSync(filePath, 'utf8'),
+    })
+  }
+}


### PR DESCRIPTION
# Why

* Close #19

# How

* Nothing else opens a Markdown file here: ESLint never reads one, and the name audit only compares directory names. A reference renamed without its links repointed would ship silently, and the skills carry `references/` files that link to each other
* Migrates the two document tools, their tests and the four fixtures from the core skills package, unchanged apart from one comment: `dist/` is made by the build skill here, which no longer flattens anything
* Checking `kit/` covers what is published, because `dist/` is a verbatim copy of it
