### PR TITLE
📦️ Declare the Node version in `engines`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@openreachtech/hora-skills-ort-support",
       "version": "0.0.0",
       "license": "Apache-2.0",
+      "bin": {
+        "hora-skills-ort-support": "lib/equip/hora-skills-ort-support.js"
+      },
       "devDependencies": {
         "@openreachtech/eslint-config": "^4.5.0",
         "@openreachtech/jest-constructor-spy": "^1.1.2",
@@ -18,6 +21,9 @@
         "@types/jest": "^30.0.0",
         "eslint": "^9.39.5",
         "jest": "^30.4.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "url": "https://github.com/openreachtech/hora-skills-ort-support/issues"
   },
   "homepage": "https://github.com/openreachtech/hora-skills-ort-support#readme",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

* Close #23

# How

* Declares `node: ">=20.0.0"`, the floor `hora-skills` and `hora-core` both declare and the one the README states
* Better now than after publishing: `engines` is part of what the tarball carries, and the three sibling packages went out at `0.0.0` without it while their READMEs claim it — fixing that there needs a release of its own
