### PR TITLE
📄 Bump the package version to `0.1.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/hora-skills-ort-support",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/hora-skills-ort-support",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "bin": {
         "hora-skills-ort-support": "lib/equip/hora-skills-ort-support.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/hora-skills-ort-support",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Distributes the ORT support skills used to develop with Hora Kit.",
   "type": "module",
   "files": [


### PR DESCRIPTION
# Why

* Close #36

# How

* `package.json` and `package-lock.json` go to `0.1.0`, and nothing else changes
* This is the last pull request on the line: the two issues that opened it, #32 and #34, are both closed, so the version is the only thing left before publishing
