### PR TITLE
🛡️ Update `@humanfs/node` to `0.16.8` for `GHSA-p498-v437-472g`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -736,25 +736,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }


### PR DESCRIPTION
# Why

* Close #50

# How

* **`GHSA-p498-v437-472g` (MODERATE) covers `@humanfs/node@0.16.7`**, where a recursive copy follows a symlinked file and copies data from outside the source tree. `eslint` is its only dependant and the package is `dev` only, so nothing the tarball carries is reached — but the `npm audit` gate in `.github/workflows/test.yml` fails on any advisory, so the tree could not ship as it stood
* **What was stale is the resolution, not the range.** `eslint` asks for `^0.16.6`, which `0.16.8` already satisfies, so lifting the lockfile was enough to clear the report. `@humanfs/core` follows to `0.19.2` and `@humanfs/types@0.15.0` arrives as its new dependency; all three stay `dev: true`
* **The override then states the floor**, the way `ccd8204` and `ac0211a` each did although the patched version satisfied the range that had asked for it. The lockfile alone carries no record of why `0.16.8` is required, and that record is what `package.json` is for. One major line is present, so the key needs no scope
* **The floor takes no companion lockfile commit.** At `lockfileVersion 3` the lockfile records no `overrides`, and `0.16.8` is already resolved there, so `npm install` leaves it untouched — unlike `a7b57bd`, which existed because the two earlier overrides moved real resolutions
* `0.16.8` was published 139 days ago, so it clears the `min-release-age` of `7` the project sets, as do the two that came with it
* Verified with `npm audit` (`found 0 vulnerabilities`), `npm run lint`, `npm test` (10 suites, 317 tests) and `npm run skill-names` (3 skills, no problem found)

# Note

* `POST /-/npm/v1/security/advisories/bulk` was intermittently unresponsive throughout this work — the upload completes and nothing comes back, while everything the Cloudflare edge answers itself returns in under a quarter second. `npm audit` reports that as a `network timeout` and fails without retrying, so read a red gate before believing it: when the cause is npm's side, the message names that endpoint