### PR TITLE
🤖 Fence a handed-over body as one block in /hos-gh-issue and /hos-gh-pull-request

### DIFF
--- a/kit/skills/hos-gh-issue/SKILL.md
+++ b/kit/skills/hos-gh-issue/SKILL.md
@@ -133,6 +133,8 @@ stops matching it.
 **Inside fenced blocks, so it can be read and copied.** The title and the body go in separate
 blocks, because they are two fields on the form and two arguments on the command.
 
+- **The body goes in one fenced block, whatever it contains.** Split across two, it needs a
+  label to say which half is which, and that label is pasted into GitHub along with them
 - **Where the body contains a fenced block of its own, fence the whole thing with four backticks
   or more.** Three would end the block at the first inner fence
 - **Nothing but the issue text goes inside the fence.** Commentary, a heading saying "body", an

--- a/kit/skills/hos-gh-pull-request/SKILL.md
+++ b/kit/skills/hos-gh-pull-request/SKILL.md
@@ -117,6 +117,8 @@ explicit instruction wins.
 **Inside fenced blocks, so it can be read and copied.** The title and the body go in separate
 blocks, because they are two fields on the form and two arguments on the command.
 
+- **The body goes in one fenced block, whatever it contains.** Split across two, it needs a
+  label to say which half is which, and that label is pasted into the form along with them
 - **Where the body contains a fenced block of its own, fence the whole thing with four backticks or
   more.** Three would end the block at the first inner fence
 - **Nothing but the pull request text goes inside the fence.** Commentary belongs outside it, or it


### PR DESCRIPTION
# Why

* Close #66

# How

The rule went in as a bullet at the head of the existing `How the text is shown` list in both
skills, rather than as a section of its own. What it settles is how many fenced blocks the body
occupies, and that is decided before the four-backtick rule decides how each one is fenced — so it
reads first in the same list instead of opening a heading that would separate it from the two rules
it governs.

The wording differs by one word between the two skills: the issue skill says the label is pasted
into GitHub, the pull request skill says it is pasted into the form. Each names the surface its own
text lands on, so neither borrows the other's vocabulary.

# Note

`#55 🚀 Publish 0.3.0` is the only sub-issue of `#47` left open once this merges, so
`release/0.3.0` is ready for its main-bound pull request from here.
