### PR TITLE
🤖 Fix the hub title rule in `/hos-gh-issue`

### DIFF
--- a/kit/skills/hos-gh-issue/SKILL.md
+++ b/kit/skills/hos-gh-issue/SKILL.md
@@ -46,9 +46,22 @@ says nothing and costs the reader a stop.
 **Inside an H1 section, headings from H2 down may be used.** Depth is not capped, and grouping a
 long `# Checklist` under H2s is the ordinary use.
 
-**Asked for a hub, the issue is a hub.** The word settles the type and the shape in one go: the
-title opens with `📂 Hub`, `# Checklist` is not written at all, and `# Sub-issues` stands where
-it would have. A hub with work of its own is not a hub — that work belongs in one of the children.
+**Asked for a hub, the issue is a hub.** The word settles the type and the shape in one go:
+`# Checklist` is not written at all, and `# Sub-issues` stands where it would have. A hub with
+work of its own is not a hub — that work belongs in one of the children.
+
+**A hub's title takes one of two forms, and the word `Hub` appears in neither.**
+
+```
+📂 Release `1.4.0`                          gathering a release — the version is the whole title
+📂 The move off the legacy mail templates    any other hub — what the whole of it is about
+```
+
+A hub that gathers a release is titled by that release and nothing else. Every other hub is
+titled by the overview of what it gathers, at the altitude the children sit beneath.
+
+**Writing `Hub` into the title says nothing the emoji has not already said**, and it spends the
+first words on a label instead of on the thing a reader opened the issue for.
 
 **The two checkbox sections are not interchangeable.** A box under `# Checklist` is work done
 inside this issue; a box under `# Sub-issues` is an issue that does not exist yet, written as the

--- a/kit/skills/hos-gh-issue/references/types.md
+++ b/kit/skills/hos-gh-issue/references/types.md
@@ -63,8 +63,20 @@ action.
 
 ## Where a hub differs
 
-**`📂 Hub` is the one type whose body is shaped differently.** It carries the situation and the
-direction, then its children:
+**`📂 Hub` is the one type whose title and body are both shaped differently.**
+
+The title takes one of two forms, and the word `Hub` appears in neither:
+
+```
+📂 Release `1.4.0`                          gathering a release — the version is the whole title
+📂 The move off the legacy mail templates    any other hub — what the whole of it is about
+```
+
+A release hub is titled by its version alone; every other hub is titled by the overview of what
+it gathers. `Hub` in the title says nothing the emoji has not, and it costs the reader the words
+that would have told them what the group is.
+
+The body carries the situation and the direction, then its children:
 
 ```markdown
 # As-is


### PR DESCRIPTION
# Why

* Close #73

# How

* The `📂 Hub` prefix is replaced by two forms rather than by one, because a release hub and every other hub are scanned for different things. A release hub is looked up by its version, so the version is the whole title; every other hub has no such key, so the title carries the overview of what it gathers.
* The altitude is stated as part of the second form. Without it, "what it gathers" invites a title written at the altitude of one child, which is the same failure as `Hub` in a different place.
* Both copies of the rule are edited where they stand — `SKILL.md` under `## The body`, `references/types.md` under `## Where a hub differs` — rather than being collapsed into one. The two files are read on their own, and the skill already keeps the hub rule twice by design.
* The `📂 Hub` row of the type table is left untouched. There the word is the type's name, and the table is what names the types.

# Note

* The rule reaches a consuming repository through `dist/skills/`, which is built at release, so nothing changes for a consumer until the next release.
