### PR TITLE
🛡️ Update `js-yaml` to `3.15.2` and `4.3.2` for `GHSA-2883-xcg3-v3hh`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -861,9 +861,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4358,9 +4358,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
# Why

* Close #75

# How

* `npm audit fix` and nothing else. Both parents already accept a patched version -- `@eslint/eslintrc` asks for `js-yaml@^4.3.0` and `@istanbuljs/load-nyc-config` for `js-yaml@^3.13.1` -- so refreshing `package-lock.json` was enough to move the `4` line to `4.3.2` and the `3` line to `3.15.2`
* An `overrides` entry was considered and dropped. It would pin what the ranges already allow, and the entries this repository carries for `brace-expansion@5` and `flatted` are there because those parents do not accept the patched version. `package.json` is untouched
