### PR TITLE
🤖 Add the title and `# Checklist` rules to `/hos-gh-issue`

### DIFF
--- a/kit/skills/hos-gh-issue/SKILL.md
+++ b/kit/skills/hos-gh-issue/SKILL.md
@@ -246,6 +246,25 @@ Bad   💪 Raise @humanfs/node to 0.16.8
 Good  💪 Raise `@humanfs/node` to `0.16.8`
 ```
 
+## What the `# Checklist` leaves out
+
+**What CI runs on its own is never a checklist line.** `npm test`, `npm run lint`, a typecheck,
+`npm audit` — nobody closes those by hand, and a red run blocks the merge without being asked, so
+the line adds nothing the repository was not already saying.
+
+**This holds every time.** There is no run where writing them in to be sure makes the checklist
+say more than it said without them.
+
+Running them while the work is going on is a different thing, and nothing here is against it. What
+is ruled out is standing them up as rows for somebody to close.
+
+**What CI does not watch is a checklist line.** Behaviour confirmed on a real device, a setting
+that has to take effect on an external service, a value somebody enters in a console — those close
+by hand alone, which is what a box is for.
+
+**A box is work that changes something.** Something left as it stands, and the outcome of a check,
+are neither: they belong under `# Note`.
+
 ## Two things about the checkboxes
 
 - **An issue is sometimes filed after the work is done.** Where that is what happened, hand it over

--- a/kit/skills/hos-gh-issue/SKILL.md
+++ b/kit/skills/hos-gh-issue/SKILL.md
@@ -81,6 +81,19 @@ in full.
 🗑️ Purge the unused fixtures under `tests/legacy/`
 ```
 
+**The title names the work, not the file the diff happens to concentrate in.** The test is
+whether the file is the decision or the place the decision was recorded. A file purged, a
+document written, a lock file regenerated because it had drifted from the manifest — each of
+those is the work, and the title names it. The same lock file moved by an install that raised a
+dependency is where the work came out, and there the title names the dependency.
+
+The second example above names a path for the first reason: purging those files is the whole of
+what the issue asks for.
+
+A title reading `Tidy up <one file>` is the usual way this goes wrong. The file shrank because
+fifteen others were fixed, and whoever opens the issue reads one file's worth of work where the
+work was the fifteen.
+
 The types, and how to pick one, are in [types.md](./references/types.md).
 
 ## `# Sub-issues` empties itself

--- a/kit/skills/hos-gh-issue/SKILL.md
+++ b/kit/skills/hos-gh-issue/SKILL.md
@@ -94,6 +94,12 @@ A title reading `Tidy up <one file>` is the usual way this goes wrong. The file 
 fifteen others were fixed, and whoever opens the issue reads one file's worth of work where the
 work was the fifteen.
 
+**A title that has stopped describing the work is corrected while the work is still running.** A
+title is written before the work exists, so it is a guess the work is free to outrun, and going
+stale is not a defect in the original. Correct it, and bring the branch name and the trunk's
+opening marker along — those two belong to the git branch convention, and what is worth having is
+the three of them saying one thing.
+
 The types, and how to pick one, are in [types.md](./references/types.md).
 
 ## `# Sub-issues` empties itself


### PR DESCRIPTION
# Why

* Close #79

# How

* Three rules, three commits, each one a rule a reviewer can take or leave on its own. The two title rules arrive in the file as one block of prose, so the split went below file granularity rather than letting the file boundary decide it.
* The stale-title rule points at `hoc-git-branch` for the branch name and the `Start …` marker instead of restating what that convention says. A second copy of a rule is a copy that disagrees with the first one the moment either is edited.
* What `# Checklist` leaves out went in as a section of its own ahead of `## Two things about the checkboxes`, not as bullets inside it. That section is about a box stating what is true; this one is about which rows exist at all, and folding them would leave one heading answering two questions.
* The rule is written as holding every time, with no run where writing the CI commands in to be sure is allowed. A rule with a discretionary exception is one every future run re-argues.

# Note

* Independent of the pull request for #80. The two touch disjoint files, so either order merges cleanly and neither needs rebasing on the other.
