### PR TITLE
🤖 Fix what the harvest of `/hos-skillify` loses

### DIFF
--- a/kit/skills/hos-skillify/SKILL.md
+++ b/kit/skills/hos-skillify/SKILL.md
@@ -156,6 +156,22 @@ phase 5's question, and asking it twice wastes the reading that phase 3 has not 
 Mark a subject with one weak passage as `thin`, and say whether it is better dropped or
 folded into another.
 
+**A `thin` verdict counts passages; it does not report what they establish.** This phase is
+deliberately too shallow to judge that — the artefacts and the words of the correction, and no
+further — so `thin` is a count with a guess attached to it. **The caller overrides it without
+owing an argument.**
+
+Measured across two runs, `thin` was wrong both times it was used. One subject was marked on a
+misreading of how its exchange had closed, and produced two rows. The other was marked because no
+skill seemed to hold it, and produced four rows across two skills.
+
+**The second is the failure the column invites.** `New`, `addition` and `thin` sit in one cell
+while answering two different questions: the first two say which skill, the third says how much
+material. A subject with no obvious home is not thin, and a subject with one weak passage can have
+an obvious home. **Where a subject looks homeless, leave `Existing skill` blank and leave
+`Proposal` alone** — which skill it belongs to is settled at the sift, with the reading this phase
+has not done.
+
 Where the subjects are to be split rather than merged, say so with the reason. The reason
 is not a matter of taste: a skill's prefix has to match the directory it sits in, so
 subjects that fall in one domain **can** become one skill, and subjects spread across

--- a/kit/skills/hos-skillify/references/transcript.md
+++ b/kit/skills/hos-skillify/references/transcript.md
@@ -90,6 +90,32 @@ that share their type. An assistant record's `content` is a list too, holding `t
 
 Report the counts at phase 1. They tell the caller the size of what is about to be read.
 
+## A message sent while the assistant is working
+
+**It is not a `type: "user"` record.** A person who types while a turn is still running has
+that message queued, and it reaches the transcript by three routes, none of them the one the
+section above describes:
+
+| Where it lands | Shape |
+| :-- | :-- |
+| `type: "queue-operation"` | The queue's own record. Two per message, as it is taken in and as it is taken up |
+| `type: "attachment"` | A mirror of the text, injected into the turn that was already running |
+| `type: "user"` | Quoted inside a `tool_result` block, once per tool call the message reached |
+
+**So a harvest that reads `type: "user"` and excludes tool results sees none of the three.**
+Measured on one session: 16 messages arrived this way against 68 ordinary turns, and one of
+them — a correction overturning the assistant's reading of a convention — appears in the file
+as no `type: "user"` record at all.
+
+- **Take the text from `queue-operation`.** The attachment and the `tool_result` quotation are
+  copies of the same message, and one message is one passage however many times it was
+  mirrored.
+- **`last-prompt` does not close the gap.** It carries a person's words, but it mirrors
+  ordinary turns only, never a queued one.
+- These are the passages most worth having. Somebody types mid-turn because something is going
+  wrong *now*, which is exactly the shape the harvest is looking for — and a run that misses
+  them loses its sharpest corrections while reporting a healthy count of turns.
+
 ## What to harvest
 
 Not the procedure. **The procedure is in the diff; what is not in the diff is why the

--- a/kit/skills/hos-skillify/references/transcript.md
+++ b/kit/skills/hos-skillify/references/transcript.md
@@ -49,7 +49,7 @@ predecessors, and the chain ends at a transcript that summarises nothing.
 
 ## What a line is
 
-Each line is an object with a `type`. Only three carry material:
+Each line is an object with a `type`. Three of them carry the bulk of the material:
 
 | `type` | What it is |
 | :-- | :-- |
@@ -57,7 +57,16 @@ Each line is an object with a `type`. Only three carry material:
 | `assistant` | Text, tool calls, or both |
 | `attachment` | Injected context — reminders, file contents, notices |
 
-The rest are bookkeeping: modes, titles, cost, file-history snapshots. Ignore them.
+**Which types are present is read off the file, not assumed.** Enumerate every `type` the
+transcript holds and account for each one before deciding what to skip. Counted on one
+session: `assistant` 949, `attachment` 592, `user` 556, `mode` 157, `permission-mode` 157,
+`atis-latch` 157, `ai-title` 157, `last-prompt` 157, `system` 103, `file-history-snapshot`
+86, `queue-operation` 38, `file-history-delta` 20.
+
+Nine of those twelve look like bookkeeping — modes, titles, cost, file-history snapshots —
+and **one of the nine carried the person's own words.** That is what the enumeration is for.
+It costs one pass over the file; skipping it means harvesting the types some earlier run
+happened to find, on a format nobody has promised to hold still.
 
 ## Telling a person's turn from a tool result
 


### PR DESCRIPTION
# Why

* Close #80

# How

* Three rules, three commits: the `thin` verdict in `SKILL.md` at phase 2, and the two transcript-reading rules in `references/transcript.md`.
* The sentence introducing the type table changed in the same commit as the enumeration rule rather than in one of its own. `Only three carry material` is the assumption that rule overturns, so splitting them would leave a commit whose document contradicts itself.
* The type table keeps its three rows instead of growing to twelve. The enumeration is a step the run performs against the file in front of it, not a list the document promises — the counts quoted are from one session, and the format is not one anybody has undertaken to hold still.
* The queued-message section sits after the counts reported at phase 1 and before `## What to harvest`, so it is met while the reader is still on how a transcript is read rather than after they have started deciding what to keep.
* The `thin` rule stayed inside phase 2 rather than moving to the sift. The column it corrects is phase 2's own output, and the correction is that the phase is too shallow to judge what it was being asked to judge.

# Note

* Independent of the pull request for #79. The two touch disjoint files, so either order merges cleanly and neither needs rebasing on the other.
